### PR TITLE
Add Maven Tools MCP to Build Tools & Dependency Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [modelcontextprotocol/server-puppeteer](https://github.com/modelcontextprotocol/servers/tree/main/server-puppeteer) 📇 🏠 - Browser automation for web scraping and interaction
 - [ndthanhdev/mcp-browser-kit](https://github.com/ndthanhdev/mcp-browser-kit) 📇 🏠 - An MCP Server for interacting with manifest v2 compatible browsers.
 
+## Build Tools & Dependency Management
+
+### 🔧 Dependency Analysis
+Tools for analyzing and managing project dependencies across build systems.
+
+- [arvindand/maven-tools-mcp](https://github.com/arvindand/maven-tools-mcp) ☕ ☁️ 🏠 🍎 🪟 🐧 - Universal Maven Central dependency intelligence for JVM build tools (Maven, Gradle, SBT, Mill). Provides version lookups, dependency health checks, age analysis, release patterns, and upgrade guidance with Context7 integration.
+
 ## Monitoring & Observability
 
 ### 📊 Metrics & Monitoring


### PR DESCRIPTION
Adding Maven Tools MCP - helps manage dependencies for JVM projects (Maven, Gradle, SBT, Mill).

I noticed there wasn't a Build Tools section, so I created one between CI/CD and Monitoring. Let me know if you'd prefer it somewhere else!

**Features:**
- Check latest versions and dependency health
- Analyze multiple dependencies at once
- Track dependency age and release patterns
- Get upgrade guidance with Context7 integration

**Why it fits here:**
Dependency management is pretty critical for DevOps - helps catch aging dependencies, supports CI/CD pipelines, and works with all the major JVM build tools.

Repo: https://github.com/arvindand/maven-tools-mcp
Docker: `arvindand/maven-tools-mcp:latest`