### PR TITLE
Add Kunobi — Kubernetes IDE with embedded MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Tools for providing visibility across the entire DevOps lifecycle.
 - [SBDI/mcp-devps-hub](https://github.com/SBDI/mcp-devps-hub) 🐍 🏠 - MCP server for end-to-end development visibility (Jira, GitHub, CI/CD, etc.).
 - [Acid-base/FastMCP-Proper](https://github.com/Acid-base/FastMCP-Proper) 🐍 🏠 - Python MCP server with CI/CD tooling and testability built-in.
 - [gofireflyio/firefly-mcp](https://github.com/gofireflyio/firefly-mcp) 🎖️ 📇 ☁️ - Integrates, discovers, manages, and codifies cloud resources with [Firefly](https://firefly.ai).
-- [Kunobi](https://kunobi.ninja) 📇 🏠 🍎 🪟 🐧 - Kubernetes desktop IDE with an embedded MCP server, providing visual oversight of AI-driven cluster operations. Supports FluxCD, ArgoCD, Helm, and expanding to infrastructure beyond Kubernetes.
+- [kunobi-ninja/kunobi](https://github.com/kunobi-ninja/kunobi) 📇 🏠 🍎 🪟 🐧 - Kubernetes desktop IDE with an embedded MCP server, providing visual oversight of AI-driven cluster operations. Supports FluxCD, ArgoCD, Helm, and expanding to infrastructure beyond Kubernetes.
 
 ### 👨‍💻 Code Execution
 Code execution servers. Allow LLMs to execute code in a secure environment.


### PR DESCRIPTION
## What is @kunobi/mcp?

[@kunobi/mcp](https://www.npmjs.com/package/@kunobi/mcp) is the MCP bridge to [Kunobi](https://kunobi.ninja), a desktop platform management IDE. AI assistants manage Kubernetes, FluxCD, ArgoCD, and Helm while users maintain real-time visual oversight.

**How it works:**

```
AI assistant <--stdio--> @kunobi/mcp <--HTTP--> Kunobi (port 3030)
```

Enable MCP in Kunobi's settings, add the server to your AI assistant, and you're ready to go. Tools appear and disappear dynamically as Kunobi connects/disconnects — no restart required.

![Kunobi — MCP settings](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/mcp.png)

**Kunobi key features:**

- Real-time cluster visibility with resource browser, YAML editor, and embedded terminal
- Native FluxCD, ArgoCD, and Helm support
- Available on macOS, Windows, and Linux
- No account required, no cloud dependency

![Kunobi](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/main.png)

![Kunobi — Cluster view](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/nodes.png)

**Website:** https://kunobi.ninja
**npm:** [@kunobi/mcp](https://www.npmjs.com/package/@kunobi/mcp)
**GitHub:** [kunobi-ninja/mcp](https://github.com/kunobi-ninja/mcp)