### PR TITLE
Add Testing & Chaos Engineering section with mcp-chaos-rig

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ Code execution servers. Allow LLMs to execute code in a secure environment.
 - [ckanthony/openapi-mcp](https://github.com/ckanthony/openapi-mcp) 🏎️ ☁️ - OpenAPI-MCP: Dockerized MCP Server to allow your AI agent to access any API with existing api docs.
 - [alfonsograziano/node-code-sandbox-mcp](https://github.com/alfonsograziano/node-code-sandbox-mcp) 📇 🏠 – A Node.js MCP server that spins up isolated Docker-based sandboxes for executing JavaScript snippets with on-the-fly npm dependency installation and clean teardown
 
+### 🧪 Testing & Chaos Engineering
+Tools for testing, fault injection, and resilience validation.
+
+- [Typewise/mcp-chaos-rig](https://github.com/Typewise/mcp-chaos-rig) 📇 🏠 - A local MCP server that breaks on demand. Test your client against auth failures, disappearing tools, flaky responses, and token expiry, all from a web UI.
+
 ### 🤖 Coding Agents
 Full coding agents that enable LLMs to read, edit, and execute code and solve general programming tasks completely autonomously.
 


### PR DESCRIPTION
## New Section: Testing & Chaos Engineering

Adds a new category for testing and chaos engineering tools, which was missing from the list.

## MCP Chaos Rig

A local MCP server that breaks on demand, built for testing MCP clients against real failure scenarios.

Lets you toggle auth failures (401s, 500s, token expiry, refresh rejection), disable tools mid-session (triggering `tools/changed`), switch tool schemas between versions, and inject random latency and failure rates. Ships with a web UI control panel and a live request log.

**Repo:** https://github.com/Typewise/mcp-chaos-rig
**npm:** https://www.npmjs.com/package/mcp-chaos-rig
**Install:** `npx mcp-chaos-rig`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Testing & Chaos Engineering" subsection to the documentation, detailing testing approaches, fault injection techniques, and resilience validation methods for code execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->