### PR TITLE
Add Taskade MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Tools for managing projects, issues, and workflows.
 
 - [nguyenvanduocit/jira-mcp](https://github.com/nguyenvanduocit/jira-mcp) 🏎️ ☁️ - A Go-based MCP connector for Jira that enables AI assistants like Claude to interact with Atlassian Jira. This tool provides a seamless interface for AI models to perform common Jira operations including issue management, sprint planning, and workflow transitions.
 - [sooperset/mcp-atlassian](https://github.com/sooperset/mcp-atlassian) 🐍 ☁️ - MCP server for Atlassian products (Confluence and Jira). Supports Confluence Cloud, Jira Cloud, and Jira Server/Data Center. Provides comprehensive tools for searching, reading, creating, and managing content across Atlassian workspaces.
+- [taskade/mcp](https://github.com/taskade/mcp) 📇 ☁️ - Official Taskade MCP server with 62+ tools for managing workspaces, projects, tasks, AI agents, templates, and media. Enables AI assistants to interact with Taskade for project management, task tracking, and workflow automation.
 
 ## Frameworks
 


### PR DESCRIPTION
## Add Taskade MCP Server

Adds [Taskade MCP Server](https://github.com/taskade/mcp) to the Project Management section.

**Taskade MCP Server** (`@taskade/mcp-server`) is the official MCP server for [Taskade](https://www.taskade.com/) with 62+ tools for managing workspaces, projects, tasks, AI agents, templates, and media. It enables AI assistants to interact with Taskade for project management, task tracking, and workflow automation.

- GitHub: https://github.com/taskade/mcp
- npm: `@taskade/mcp-server`
- License: MIT
- Language: TypeScript

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about Taskade MCP server integration, providing 60+ tools for workspace, project, and task management while enabling AI assistants to interact with Taskade for workflow automation and task tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->