### PR TITLE
Add flutter-skill: AI E2E testing MCP server for 8 platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Code execution servers. Allow LLMs to execute code in a secure environment.
 Tools for testing, fault injection, and resilience validation.
 
 - [Typewise/mcp-chaos-rig](https://github.com/Typewise/mcp-chaos-rig) 📇 🏠 - A local MCP server that breaks on demand. Test your client against auth failures, disappearing tools, flaky responses, and token expiry, all from a web UI.
+- [ai-dashboad/flutter-skill](https://github.com/ai-dashboad/flutter-skill) - AI-powered E2E testing bridge for any app. Supports Flutter, iOS, Android, Web, Electron, Tauri, KMP, React Native, .NET MAUI.
 
 ### 🤖 Coding Agents
 Full coding agents that enable LLMs to read, edit, and execute code and solve general programming tasks completely autonomously.


### PR DESCRIPTION
Add [flutter-skill](https://github.com/ai-dashboad/flutter-skill) — an AI-powered E2E testing MCP server that supports 8 platforms: Flutter, iOS, Android, Web, Electron, Tauri, KMP, React Native, and .NET MAUI.

Currently passing 181/183 tests. Provides a bridge between AI agents and app testing across multiple frameworks through the Model Context Protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about ai-dashboard/flutter-skill, an AI-powered E2E testing bridge for multiple platforms, to the Testing & Chaos Engineering documentation section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->