### PR TITLE
Add VMware-AIops MCP server to Cloud Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Tools for managing containers, Kubernetes clusters, and related orchestration pl
 
 #### Other Cloud Platforms
 - [bright8192/esxi-mcp-server](https://github.com/bright8192/esxi-mcp-server) 🐍 ☁️ - A VMware ESXi/vCenter management server based on MCP (Model Control Protocol), providing simple REST API interfaces for virtual machine management.
+- [zw008/VMware-AIops](https://github.com/zw008/VMware-AIops) 🐍 ☁️ - AI-powered VMware vCenter/ESXi monitoring and operations via MCP: inventory queries (VMs, hosts, datastores, clusters), health/alarms/events, VM lifecycle (create, delete, snapshot, clone, migrate), vSAN management, Aria Operations analytics, and scheduled log scanning with webhook notifications.
 - [cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) 🎖️ 📇 ☁️ - Integration with Cloudflare services including Workers, KV, R2, and D1.
 - [thunderboltsid/mcp-nutanix](https://github.com/thunderboltsid/mcp-nutanix) 🏎️ 🏠/☁️ - Go-based MCP Server for interfacing with Nutanix Prism Central resources.
 


### PR DESCRIPTION
## Summary
Add [VMware-AIops](https://github.com/zw008/VMware-AIops) MCP server to the Other Cloud Platforms section.

## About
AI-powered VMware vCenter/ESXi monitoring and operations MCP server built with Python (pyVmomi). Covers inventory, health monitoring, VM lifecycle, vSAN, Aria Operations, and scheduled scanning.

- GitHub: https://github.com/zw008/VMware-AIops
- License: MIT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the list of supported cloud platforms with an enhanced VMware integration offering expanded capabilities including inventory management, health monitoring, VM lifecycle operations, and analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->