### PR TITLE
Add frostbyte-mcp to Aggregators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 - [askbudi/roundtable](https://github.com/askbudi/roundtable) 🐍 🏠 - Zero-configuration MCP server that unifies multiple AI coding assistants (Codex, Claude Code, Cursor, Gemini) through intelligent auto-discovery and standardized interface.
 - [Composiohq/Rube](https://github.com/composiohq/rube) - Rube is an MCP server built on the Composio integration platform. It connects your AI tools to 500+ apps.
-- [OzorOwn/frostbyte-mcp](https://github.com/OzorOwn/frostbyte-mcp) 📇 ☁️ - Developer API toolkit MCP server with 13 tools (IP geolocation, crypto prices, DNS/WHOIS lookup, screenshots, web scraping, code execution, web search, URL shortener, PDF generation, pastebin, data conversion, domain check). One API key for 40+ services.
+- [OzorOwn/frostbyte-mcp](https://github.com/OzorOwn/frostbyte-mcp) 📇 🏠 - Developer API toolkit MCP server with 13 tools (IP geolocation, crypto prices, DNS lookup, WHOIS lookup, screenshots, web scraping, code execution, web search, URL shortener, PDF generation, pastebin, data conversion, domain check). One API key for 40+ services.
 - [julien040/anyquery](https://github.com/julien040/anyquery) 🏎️ 🏠 ☁️ - Query more than 40 apps with one binary using SQL. It can also connect to your PostgreSQL, MySQL, or SQLite compatible database. Local-first and private by design.
 - [metatool-ai/metatool-app](https://github.com/metatool-ai/metatool-app) 📇 ☁️ 🏠 🍎 🪟 🐧 - MetaMCP is the one unified middleware MCP server that manages your MCP connections with GUI.
 - [mindsdb/mindsdb](https://github.com/mindsdb/mindsdb) - Connect and unify data across various platforms and databases with [MindsDB as a single MCP server](https://docs.mindsdb.com/mcp/overview).


### PR DESCRIPTION
## Description

Adds [frostbyte-mcp](https://github.com/OzorOwn/frostbyte-mcp) to the **🔗 Aggregators** section.

Frostbyte MCP is a developer API toolkit MCP server that aggregates 13 tools under a single interface with one API key:

- IP geolocation
- Crypto prices
- DNS/WHOIS lookup
- Screenshots
- Web scraping
- Code execution
- Web search
- URL shortener
- PDF generation
- Pastebin
- Data conversion
- Domain availability check
- And more (40+ underlying services)

## Badges

- 📇 TypeScript/Node.js
- ☁️ Cloud-hosted service

## Checklist

- [x] Entry added alphabetically within the Aggregators section
- [x] Follows the existing format: `[owner/repo](url) badge1 badge2 - description`
- [x] Description is concise and accurately describes the tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new entry to the Aggregators list describing an additional aggregator with details on available tools and API key coverage. No other documentation, structural, or functional changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->