### PR TITLE
Add evc-team-relay-mcp to Project Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Tools for managing projects, issues, and workflows.
 
 - [nguyenvanduocit/jira-mcp](https://github.com/nguyenvanduocit/jira-mcp) 🏎️ ☁️ - A Go-based MCP connector for Jira that enables AI assistants like Claude to interact with Atlassian Jira. This tool provides a seamless interface for AI models to perform common Jira operations including issue management, sprint planning, and workflow transitions.
 - [sooperset/mcp-atlassian](https://github.com/sooperset/mcp-atlassian) 🐍 ☁️ - MCP server for Atlassian products (Confluence and Jira). Supports Confluence Cloud, Jira Cloud, and Jira Server/Data Center. Provides comprehensive tools for searching, reading, creating, and managing content across Atlassian workspaces.
+- [entire-vc/evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp) 🐍 ☁️ - MCP server for Obsidian vault access, enabling AI agents to read and write team documentation, runbooks, and knowledge base notes through the Model Context Protocol.
 
 ## Frameworks
 


### PR DESCRIPTION
## Add evc-team-relay-mcp

Adding [evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp) to the Project Management section - an MCP server for Obsidian vault access.

**What it does:** Gives AI coding tools (Claude Code, Cursor, Windsurf, Codex) read/write access to Obsidian vault notes through the Model Context Protocol. Useful for DevOps teams maintaining documentation, runbooks, and knowledge bases in Obsidian.

**Tools:** list_shares, list_files, read_file, upsert_file, write_document, delete_file

**Install:** `uvx evc-team-relay-mcp` (PyPI)

**Links:**
- Repository: https://github.com/entire-vc/evc-team-relay-mcp
- PyPI: https://pypi.org/project/evc-team-relay-mcp/
- Homepage: https://entire.vc/team-relay/ai/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new MCP server entry enabling Obsidian vault access via the Model Context Protocol in the Project Management section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->