### PR TITLE
Add Xquik X/Twitter monitoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,11 @@ Tools for collecting, querying, and analyzing metrics in DevOps environments.
 - [loginmqv/mcp-server-prometheus](https://github.com/loginmqv/mcp-server-prometheus) 📇 ☁️ - MCP server for interacting with Prometheus, enabling AI assistants to query and analyze metrics data.
 - [pab1it0/prometheus-mcp-server](https://github.com/pab1it0/prometheus-mcp-server) 🐍 ☁️ - A Model Context Protocol server that enables AI assistants to query and analyze Prometheus metrics through standardized interfaces.
 - [VictoriaMetrics-Community/mcp-victoriametrics](https://github.com/VictoriaMetrics-Community/mcp-victoriametrics) 🏎️ ☁️ - The implementation of Model Context Protocol (MCP) server for VictoriaMetrics. This provides access to your VictoriaMetrics instance and seamless integration with VictoriaMetrics APIs and documentation.
-- [Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) 📇 ☁️ - X/Twitter account monitoring and data extraction — MCP server, REST API, HMAC webhooks, 20 extraction tools.
+
+### 📱 Social Media Monitoring
+Tools for monitoring social media platforms and extracting data.
+
+- [Xquik](https://xquik.com) 📇 ☁️ - X/Twitter account monitoring and data extraction — MCP server, REST API, HMAC webhooks, 40+ extraction tools.
 
 ### 🔔 Alerting & Notification
 Tools for managing alerts and notifications in monitoring systems.


### PR DESCRIPTION
Add [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) to the Monitoring & Observability > Metrics & Monitoring section.

Xquik is an X/Twitter account monitoring and data extraction platform with an MCP server, REST API, HMAC webhooks, and 20 extraction tools.

Disclosure: I am the developer of Xquik.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Social Media Monitoring entry for Xquik (X/Twitter MCP server) documenting REST API, HMAC webhook support, and 40+ data extraction tools.
  * Also added a duplicate Social Media Monitoring subsection with the same Xquik entry under Monitoring & Observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->