### PR TITLE
Add Ingero - eBPF-based GPU causal observability MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Tools for managing alerts and notifications in monitoring systems.
 Tools for monitoring application performance and infrastructure health.
 
 - [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) 📇 ☁️ - MCP server for Dynatrace Observability monitoring, providing AI-powered insights into application performance and infrastructure health.
-- [ingero-io/ingero](https://github.com/ingero-io/ingero) 🏎️ 🏠 - eBPF-based GPU causal observability agent with MCP server, providing AI assistants with causal chains explaining GPU latency from kernel-level CUDA API and host event tracing.
+- [ingero-io/ingero](https://github.com/ingero-io/ingero) 🏎️ 🏠 - eBPF-based GPU causal observability agent with MCP server, providing AI assistants with causal chains explaining GPU latency from CUDA Runtime/Driver API tracing and host kernel event tracing.
 - [last9/last9-mcp-server](https://github.com/last9/last9-mcp-server) 🏎️ ☁️ - Last9 MCP Server for observability and monitoring, providing AI assistants with access to metrics, logs, and traces.
 - [willibrandon/CursorMCPMonitor](https://github.com/willibrandon/CursorMCPMonitor) #️⃣ 🏠 - Real-time monitoring tool for Model Context Protocol interactions in Cursor AI editor. Track, analyze, and debug AI context exchanges.
 - [Polar Signals Remote MCP](https://www.polarsignals.com/blog/posts/2025/07/17/the-mcp-for-performance-engineering) 🐍 ☁️ - MCP server for Polar Signals Cloud continuous profiling platform, enabling AI assistants to analyze CPU performance, memory usage, and identify optimization opportunities in production systems.


### PR DESCRIPTION
Ingero is an eBPF-based GPU causal observability agent with an MCP server exposing 7 tools for AI-assisted GPU investigation. Traces CUDA Runtime/Driver APIs via uprobes and host kernel events via tracepoints. Provides causal chains linking system context (CPU, memory, I/O) to CUDA call latency with automated root cause analysis. <2% overhead, production-safe. Go + eBPF C, Apache 2.0 + GPL-2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Monitoring & Observability entry to the README describing a new GPU causal observability resource: an eBPF-based agent with MCP server that provides causal chains from CUDA and host kernel tracing to help AI assistants explain GPU latency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->