### PR TITLE
Add WritBase to DevOps Visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Tools for providing visibility across the entire DevOps lifecycle.
 - [SBDI/mcp-devps-hub](https://github.com/SBDI/mcp-devps-hub) 🐍 🏠 - MCP server for end-to-end development visibility (Jira, GitHub, CI/CD, etc.).
 - [Acid-base/FastMCP-Proper](https://github.com/Acid-base/FastMCP-Proper) 🐍 🏠 - Python MCP server with CI/CD tooling and testability built-in.
 - [gofireflyio/firefly-mcp](https://github.com/gofireflyio/firefly-mcp) 🎖️ 📇 ☁️ - Integrates, discovers, manages, and codifies cloud resources with [Firefly](https://firefly.ai).
+- [Writbase/writbase](https://github.com/Writbase/writbase) 📇 ☁️ - MCP-native task management for AI agent fleets with multi-agent permissions, provenance tracking, and delegation safety.
 
 ### 👨‍💻 Code Execution
 Code execution servers. Allow LLMs to execute code in a secure environment.


### PR DESCRIPTION
## Summary
- Adds [WritBase](https://github.com/Writbase/writbase) to the DevOps Visibility section
- WritBase is an MCP-native task management control plane for AI agent fleets with multi-agent permissions, provenance tracking, and delegation safety

## Entry
Added to the CI/CD & DevOps Pipelines > DevOps Visibility subsection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include Writbase MCP server references across DevOps and CI/CD sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->