### PR TITLE
Add AgentWatch to Application Performance Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Tools for monitoring application performance and infrastructure health.
 - [willibrandon/CursorMCPMonitor](https://github.com/willibrandon/CursorMCPMonitor) #️⃣ 🏠 - Real-time monitoring tool for Model Context Protocol interactions in Cursor AI editor. Track, analyze, and debug AI context exchanges.
 - [Polar Signals Remote MCP](https://www.polarsignals.com/blog/posts/2025/07/17/the-mcp-for-performance-engineering) 🐍 ☁️ - MCP server for Polar Signals Cloud continuous profiling platform, enabling AI assistants to analyze CPU performance, memory usage, and identify optimization opportunities in production systems.
 - [unitedideas/resolve-mcp](https://github.com/unitedideas/resolve-mcp) 🐍 ☁️ - Structured error recovery for AI agents. Returns resolution playbooks with backoff schedules, retry strategies, and recovery steps for 20+ services (OpenAI, Anthropic, Stripe, AWS, Postgres, Redis, Twilio, etc.). Complements monitoring tools by telling agents how to recover from errors, not just detect them.
+- [nicofains1/agentwatch](https://github.com/nicofains1/agentwatch) 📇 🏠 - Multi-agent observability MCP server and CLI. Detects cascade failures across agent fleets, tracks heartbeats, provides a fleet dashboard, and supports forensic replay. Run via `npx @nicofains1/agentwatch mcp`.
 
 ## Project & Service Management
 


### PR DESCRIPTION
## What this adds

[nicofains1/agentwatch](https://github.com/nicofains1/agentwatch) is an MCP server and CLI for multi-agent observability. It detects cascade failures across agent fleets before they spread, tracks per-agent heartbeats, provides a fleet dashboard, and supports forensic replay of failure events.

- npm: `@nicofains1/agentwatch`
- Run as MCP server: `npx @nicofains1/agentwatch mcp`
- TypeScript, runs locally

## Why it fits

The "Application Performance Monitoring" section covers tools that monitor health and surface failures. AgentWatch does exactly that for multi-agent AI systems — a growing deployment pattern where cascade failures are a real operational problem not covered by any existing entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new MCP server entry for multi-agent observability with features including cascade failure detection, heartbeat monitoring, fleet dashboard visualization, and forensic replay capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->