### PR TITLE
Add Arch Tools — 61 production-ready AI tools via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Servers for accessing many apps and tools through a single MCP server.
 - [sxhxliang/mcp-access-point](https://github.com/sxhxliang/mcp-access-point) 📇 ☁️ 🏠 🍎 🪟 🐧 - Turn a web service into an MCP server in one click without making any code changes.
 Consider moving this entry to a 'Databases' section if one exists, or creating one. Database-specific tools don't fit the 'Aggregators' category which is described as 'Servers for accessing many apps and tools through a single MCP server.'
 - [juspay/neurolink](https://github.com/juspay/neurolink) 📇 ☁️ 🏠 - TypeScript-first AI SDK that unifies 13 major AI providers and 100+ models under a single consistent API. Connects to remote MCP servers via addExternalMCPServer/addMCPServer APIs with built-in HTTP-based MCP connection, auth, retries, and rate limiting.
+- [Arch Tools](https://archtools.dev) ☁️ - 53 production-ready AI tools via MCP with x402 USDC payments. Web scraping, crypto data, AI generation, OCR, and more.
 
 ### 📂 Browser Automation
 Web content access and automation capabilities. Enables searching, scraping, and processing web content in AI-friendly formats.


### PR DESCRIPTION
Adds Arch Tools to the Aggregators section.

**Website:** https://archtools.dev

53 production-ready AI tools accessible via MCP with x402 USDC micropayments. Includes web scraping, crypto data, AI generation, OCR, DNS, WHOIS, and more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Arch Tools to the Aggregators section, featuring 53 AI tools via MCP with capabilities including web scraping, data payments, OCR, and more.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->