### PR TITLE
Add wopee-mcp to Testing & Chaos Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Tools for testing, fault injection, and resilience validation.
 
 - [Typewise/mcp-chaos-rig](https://github.com/Typewise/mcp-chaos-rig) 📇 🏠 - A local MCP server that breaks on demand. Test your client against auth failures, disappearing tools, flaky responses, and token expiry, all from a web UI.
 - [ai-dashboad/flutter-skill](https://github.com/ai-dashboad/flutter-skill) - AI-powered E2E testing bridge for any app. Supports Flutter, iOS, Android, Web, Electron, Tauri, KMP, React Native, .NET MAUI.
+- [autonomous-testing/wopee-mcp](https://www.npmjs.com/package/wopee-mcp) 📇 ☁️ - AI testing agents for web apps — dispatch test runs, analysis crawls, and AI agent tests, fetch artifacts and project status.
 
 ### 🤖 Coding Agents
 Full coding agents that enable LLMs to read, edit, and execute code and solve general programming tasks completely autonomously.


### PR DESCRIPTION
## Summary

Add [wopee-mcp](https://www.npmjs.com/package/wopee-mcp) to the Testing & Chaos Engineering section.

**wopee-mcp** — AI testing agents for web apps. Dispatch test runs, analysis crawls, and AI agent tests, fetch artifacts and project status.

- npm: `npx wopee-mcp@latest`
- 7 tools: wopee_dispatch_analysis, wopee_dispatch_run, wopee_dispatch_code, wopee_dispatch_agent, wopee_fetch_artifact, wopee_get_project_status, wopee_list_projects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a README entry under Testing & Chaos Engineering describing an AI-powered testing agent platform for web applications, highlighting autonomous testing agents, intelligent test dispatching, automated analysis crawls, and artifact and project status retrieval to improve test orchestration and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->