### PR TITLE
Add mcp-server-spotinst to Other Cloud Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Tools for managing containers, Kubernetes clusters, and related orchestration pl
 - [bright8192/esxi-mcp-server](https://github.com/bright8192/esxi-mcp-server) 🐍 ☁️ - A VMware ESXi/vCenter management server based on MCP (Model Control Protocol), providing simple REST API interfaces for virtual machine management.
 - [cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) 🎖️ 📇 ☁️ - Integration with Cloudflare services including Workers, KV, R2, and D1.
 - [thunderboltsid/mcp-nutanix](https://github.com/thunderboltsid/mcp-nutanix) 🏎️ 🏠/☁️ - Go-based MCP Server for interfacing with Nutanix Prism Central resources.
+- [arnstarn/mcp-server-spotinst](https://github.com/arnstarn/mcp-server-spotinst) 🐍 ☁️ - MCP server for Spot.io (Spotinst) API with 23 tools for managing Ocean clusters, VNGs, Elastigroups, costs, right-sizing, and logs across AWS and Azure with multi-account support.
 
 ### 🖥️ Command Line
 Run commands, capture output and otherwise interact with shells and command line tools.


### PR DESCRIPTION
## New Server: mcp-server-spotinst

**Repository:** https://github.com/arnstarn/mcp-server-spotinst
**PyPI:** https://pypi.org/project/mcp-server-spotinst/
**Language:** Python
**Category:** Cloud Providers > Other Cloud Platforms

### Description

MCP server for the Spot.io (Spotinst) API — the first and only MCP server for this platform. Provides 23 tools for managing Ocean Kubernetes clusters, Virtual Node Groups (VNGs), Elastigroups, cost analysis, right-sizing recommendations, and cluster logs across both AWS and Azure with full multi-account support.

### Features

- 19 read-only tools + 4 write tools with safety guards (require `confirm=true`)
- Multi-account support — query any account with a single token
- Cross-cloud scanning — list all clusters across all accounts and clouds in one call
- Cost breakdown by namespace or resource
- Right-sizing recommendations for workloads
- Cluster activity/scaling logs

### Checklist

- [x] Server has a README with setup instructions
- [x] Published to PyPI
- [x] MIT licensed
- [x] Entry placed in the appropriate section (Other Cloud Platforms)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for `arnstarn/mcp-server-spotinst`, a new MCP server resource providing tools for managing Spot.io infrastructure across AWS and Azure, supporting Ocean clusters, VNGs, Elastigroups, cost analysis, right-sizing, and logs with multi-account support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->