### PR TITLE
Add Global Chat — cross-protocol AI agent discovery MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Servers for accessing many apps and tools through a single MCP server.
 - [sxhxliang/mcp-access-point](https://github.com/sxhxliang/mcp-access-point) 📇 ☁️ 🏠 🍎 🪟 🐧 - Turn a web service into an MCP server in one click without making any code changes.
 Consider moving this entry to a 'Databases' section if one exists, or creating one. Database-specific tools don't fit the 'Aggregators' category which is described as 'Servers for accessing many apps and tools through a single MCP server.'
 - [juspay/neurolink](https://github.com/juspay/neurolink) 📇 ☁️ 🏠 - TypeScript-first AI SDK that unifies 13 major AI providers and 100+ models under a single consistent API. Connects to remote MCP servers via addExternalMCPServer/addMCPServer APIs with built-in HTTP-based MCP connection, auth, retries, and rate limiting.
+- [pumanitro/global-chat](https://github.com/pumanitro/global-chat) 📇 ☁️ - Cross-protocol AI agent discovery MCP server. Searchable directory of 18K+ MCP servers across 6+ registries (mcp.so, Glama, Smithery, PulseMCP, and more), with agents.txt validation and protocol-agnostic agent search.
 
 ### 📂 Browser Automation
 Web content access and automation capabilities. Enables searching, scraping, and processing web content in AI-friendly formats.


### PR DESCRIPTION
Adds [pumanitro/global-chat](https://github.com/pumanitro/global-chat) to the **Aggregators** section.

**Global Chat** is a cross-protocol AI agent discovery MCP server that aggregates 18K+ MCP servers across 6+ registries (mcp.so, Glama, Smithery, PulseMCP, and more). It provides:

- Searchable directory of MCP servers across multiple registries
- agents.txt validation and linting
- Protocol-agnostic agent discovery (MCP, A2A, agents.txt, ACDP)
- Published on npm: [@global-chat/mcp-server](https://www.npmjs.com/package/@global-chat/mcp-server)

**Format**: `📇 ☁️` (TypeScript codebase, Cloud Service)
**Category**: Aggregators — fits naturally as it unifies multiple MCP registries through a single MCP server interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new aggregator resource entry to the README: a cross-protocol AI agent discovery tool providing comprehensive searchable access to 18K+ MCP servers distributed across 6+ registries. The resource enables protocol-agnostic agent search with built-in agents.txt validation, enhancing discoverability and accessibility of available AI agents across multiple platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->