### PR TITLE
Add mcpware MCP servers (Claude Code Organizer, UI Annotator, Pagecast)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [eyalzh/browser-control-mcp](https://github.com/eyalzh/browser-control-mcp) 📇 🏠 - An MCP server paired with a browser extension that enables LLM clients to control the user's browser (Firefox).
 - [getrupt/ashra-mcp](https://github.com/getrupt/ashra-mcp) 🐍 🏠 - Extract structured data from any website. Just prompt and get JSON.
 - [kimtth/mcp-aoai-web-browsing](https://github.com/kimtth/mcp-aoai-web-browsing) 🐍 🏠 - A `minimal` server/client MCP implementation using Azure OpenAI and Playwright.
+- [mcpware/pagecast](https://github.com/mcpware/pagecast) 📇 🏠 - MCP server that records browser sessions as GIF/video using Playwright and ffmpeg — AI-driven QA evidence and demo recording.
+- [mcpware/ui-annotator-mcp](https://github.com/mcpware/ui-annotator-mcp) 📇 🏠 - MCP server that annotates web pages with hover labels for AI assistants — reverse proxy injects annotations, zero browser extensions needed.
 - [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) - Official Microsoft Playwright MCP server, enabling LLMs to interact with web pages through structured accessibility snapshots
 - [modelcontextprotocol/server-puppeteer](https://github.com/modelcontextprotocol/servers/tree/main/server-puppeteer) 📇 🏠 - Browser automation for web scraping and interaction
 - [ndthanhdev/mcp-browser-kit](https://github.com/ndthanhdev/mcp-browser-kit) 📇 🏠 - An MCP Server for interacting with manifest v2 compatible browsers.
@@ -286,6 +288,7 @@ Tools for managing projects, issues, and workflows.
 ### 🧠 Memory & Context
 Tools for persistent memory, context management, and knowledge retention for AI agents.
 
+- [mcpware/claude-code-organizer](https://github.com/mcpware/claude-code-organizer) 📇 🏠 - MCP server to organize Claude Code configurations — scan, move, delete memories, skills, MCP servers, and hooks across project and user scopes.
 - [omega-memory/omega-memory](https://github.com/omega-memory/omega-memory) 🐍 🏠 - Local-first persistent memory for AI agents. SQLite + ONNX embeddings, semantic search, auto-capture, checkpoint/resume. #1 on LongMemEval benchmark.
 
 ## Frameworks


### PR DESCRIPTION
## Summary

Adds three @mcpware MCP servers to the list:

- **[Claude Code Organizer](https://github.com/mcpware/claude-code-organizer)** — MCP server to organize Claude Code configurations (memories, skills, MCP servers, hooks) across project and user scopes. Added to **AI Agent Infrastructure > Memory & Context**.
- **[UI Annotator MCP](https://github.com/mcpware/ui-annotator-mcp)** — MCP server that annotates web pages with hover labels for AI assistants via reverse proxy, no browser extensions needed. Added to **Browser Automation**.
- **[Pagecast](https://github.com/mcpware/pagecast)** — MCP server that records browser sessions as GIF/video using Playwright and ffmpeg for QA evidence and demo recording. Added to **Browser Automation**.

All entries follow the existing format and are placed in alphabetical order within their sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for new browser session recording tool (GIF/video capture)
  * Added documentation for web page annotation tool with hover labels (no browser extensions required)
  * Added documentation for Claude Code configuration organizer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->