### PR TITLE
Add openobserve-community-mcp to Application Performance Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Tools for managing alerts and notifications in monitoring systems.
 ### 🔍 Application Performance Monitoring
 Tools for monitoring application performance and infrastructure health.
 
+- [alilxxey/openobserve-community-mcp](https://github.com/alilxxey/openobserve-community-mcp) 🐍 🏠 - MCP server for OpenObserve Community Edition via REST API. Read-only tools for searching logs, traces, stream schemas, and dashboards without requiring the Enterprise license.
 - [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) 📇 ☁️ - MCP server for Dynatrace Observability monitoring, providing AI-powered insights into application performance and infrastructure health.
 - [ingero-io/ingero](https://github.com/ingero-io/ingero) 🏎️ 🏠 - eBPF-based GPU causal observability agent with MCP server, providing AI assistants with causal chains explaining GPU latency from CUDA Runtime/Driver API tracing and host kernel event tracing.
 - [last9/last9-mcp-server](https://github.com/last9/last9-mcp-server) 🏎️ ☁️ - Last9 MCP Server for observability and monitoring, providing AI assistants with access to metrics, logs, and traces.


### PR DESCRIPTION
 Adds [openobserve-community-mcp](https://github.com/alilxxey/openobserve-community-mcp) to the Application Performance    
  Monitoring section.                                                                                                       
                                                                                                                            
  A read-only MCP server for OpenObserve Community Edition that works over the REST API. Provides tools for searching logs,
  traces, stream schemas, and dashboards — no Enterprise license required.                                                  
                                                                          
  - Language: Python
  - Scope: Local (stdio transport)                                                                                          
  - Published on PyPI: `openobserve-community-mcp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Application Performance Monitoring option: OpenObserve Community Edition MCP server for searching logs, traces, stream schemas, and dashboards without Enterprise licensing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->