### PR TITLE
Add claw-army/claude-node - Python subprocess bridge for Claude Code CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A curated list of awesome Model Context Protocol (MCP) servers focused on DevOps
 Tools for managing infrastructure through code, including Terraform, Pulumi, and other IaC platforms.
 
 - [dulltz/mcp-server-hcp-terraform](https://github.com/dulltz/mcp-server-hcp-terraform) 🐍 ☁️ - MCP server for working with HashiCorp Cloud Platform (HCP) Terraform, enabling AI assistants to interact with Terraform Cloud resources.
+- [claw-army/claude-node](https://github.com/claw-army/claude-node) 🐍 - Python subprocess bridge for Claude Code CLI. Gives Python code direct access to Claude Code native capabilities via stream-json.
 - [guilhermeyoshida/mcp-terraform-assistant](https://github.com/guilhermeyoshida/mcp-terraform-assistant) 🐍 🏠 - An MCP server for managing infrastructure as code using Terraform.
 - [jashkahar/Terraform-MCP-Server](https://github.com/jashkahar/Terraform-MCP-Server) 🐍 ☁️ - This project provides an MCP server that exposes Terraform infrastructure-as-code operations through natural language.
 - [nwiizo/tfmcp](https://github.com/nwiizo/tfmcp) 🦀 🏠 - A Terraform MCP server allowing AI assistants to manage and operate Terraform environments, enabling reading configurations, analyzing plans, applying configurations, and managing Terraform state.


### PR DESCRIPTION
## Project: claw-army/claude-node

Python subprocess bridge for Claude Code CLI, giving Python code direct access to Claude Code native capabilities via stream-json.

**Why this list**: This project is a Python library that enables AI agent integrations, subprocess control, and CLI automation - directly relevant to this list's scope.

**Entry**: [claw-army/claude-node](https://github.com/claw-army/claude-node)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with a new entry in the Infrastructure as Code section documenting an additional resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->