### PR TITLE
Add SkillFlow - AI Skills Marketplace Discovery MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Servers for accessing many apps and tools through a single MCP server.
 - [MetaMCP](https://github.com/metatool-ai/metatool-app) 📇 ☁️ 🏠 🍎 🪟 🐧 - MetaMCP is the one unified middleware MCP server that manages your MCP connections with GUI.
 - [WayStation-ai/mcp](https://github.com/waystation-ai/mcp) ☁️ 🍎 🪟 - Seamlessly and securely connect Claude Desktop and other MCP hosts to your favorite apps (Notion, Slack, Monday, Airtable, etc.). Takes less than 90 secs.
 - [sxhxliang/mcp-access-point](https://github.com/sxhxliang/mcp-access-point) 📇 ☁️ 🏠 🍎 🪟 🐧 - Turn a web service into an MCP server in one click without making any code changes.
-- [SkillFlow](https://github.com/rafsilva85/skillflow-mcp-server) 📦 🏠 - Open marketplace for AI agent skills. Discover 500+ MCP servers and automation tools, compare capabilities, and deploy to your AI stack. Free and open source.
+- [SkillFlow](https://github.com/rafsilva85/skillflow-mcp-server) 🌐📦🤖 - Open marketplace for AI agent skills. Discover 500+ MCP servers and automation tools, compare capabilities, and deploy to your AI stack. Free and open source.
 Consider moving this entry to a 'Databases' section if one exists, or creating one. Database-specific tools don't fit the 'Aggregators' category which is described as 'Servers for accessing many apps and tools through a single MCP server.'
 - [juspay/neurolink](https://github.com/juspay/neurolink) 📇 ☁️ 🏠 - TypeScript-first AI SDK that unifies 13 major AI providers and 100+ models under a single consistent API. Connects to remote MCP servers via addExternalMCPServer/addMCPServer APIs with built-in HTTP-based MCP connection, auth, retries, and rate limiting.
 


### PR DESCRIPTION
Adding SkillFlow MCP Server to the list.

**SkillFlow** enables AI agents to discover and search 500+ AI skills, MCP servers, and automation tools.

- npm: `skillflow-mcp-server`
- GitHub: https://github.com/rafsilva85/skillflow-mcp-server
- Website: https://skillflow.builders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "SkillFlow" to the "🔗 Aggregators" list with its link, emoji tags, and a one-line description presenting it as an open marketplace for AI agent skills, noting "500+" MCP servers/automation tools and a Free & open-source claim.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->