### PR TITLE
Add Safari MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Servers for accessing many apps and tools through a single MCP server.
 Web content access and automation capabilities. Enables searching, scraping, and processing web content in AI-friendly formats.
 
 - [aircodelabs/grasp](https://github.com/aircodelabs/grasp) 📇 🏠 - Self-hosted browser using agent with built-in MCP and A2A support.
+- [achiya-automation/safari-mcp](https://github.com/achiya-automation/safari-mcp) 📇 🏠 - Native Safari browser automation for AI agents on macOS. 80 tools (navigate, click, fill, screenshot, network mock, a11y snapshots), ~5ms per command via persistent Swift daemon, zero Chrome overhead.
 - [Automata-Labs-team/MCP-Server-Playwright](https://github.com/Automata-Labs-team/MCP-Server-Playwright) 🐍 - An MCP server for browser automation using Playwright
 - [blackwhite084/playwright-plus-python-mcp](https://github.com/blackwhite084/playwright-plus-python-mcp) 🐍 - An MCP python server using Playwright for browser automation, more suitable for llm
 - [browserbase/mcp-server-browserbase](https://github.com/browserbase/mcp-server-browserbase) 🎖️ 📇 - Automate browser interactions in the cloud (e.g. web navigation, data extraction, form filling, and more)

--- a/README.md
+++ b/README.md
@@ -235,8 +235,8 @@ Servers for accessing many apps and tools through a single MCP server.
 ### 📂 Browser Automation
 Web content access and automation capabilities. Enables searching, scraping, and processing web content in AI-friendly formats.
 
-- [aircodelabs/grasp](https://github.com/aircodelabs/grasp) 📇 🏠 - Self-hosted browser using agent with built-in MCP and A2A support.
 - [achiya-automation/safari-mcp](https://github.com/achiya-automation/safari-mcp) 📇 🏠 - Native Safari browser automation for AI agents on macOS. 80 tools (navigate, click, fill, screenshot, network mock, a11y snapshots), ~5ms per command via persistent Swift daemon, zero Chrome overhead.
+- [aircodelabs/grasp](https://github.com/aircodelabs/grasp) 📇 🏠 - Self-hosted browser using agent with built-in MCP and A2A support.
 - [Automata-Labs-team/MCP-Server-Playwright](https://github.com/Automata-Labs-team/MCP-Server-Playwright) 🐍 - An MCP server for browser automation using Playwright
 - [blackwhite084/playwright-plus-python-mcp](https://github.com/blackwhite084/playwright-plus-python-mcp) 🐍 - An MCP python server using Playwright for browser automation, more suitable for llm
 - [browserbase/mcp-server-browserbase](https://github.com/browserbase/mcp-server-browserbase) 🎖️ 📇 - Automate browser interactions in the cloud (e.g. web navigation, data extraction, form filling, and more)


### PR DESCRIPTION
Adds [Safari MCP](https://github.com/achiya-automation/safari-mcp) — native Safari browser automation for AI agents. 80 tools via AppleScript, zero Chrome overhead, MIT licensed.

- **npm**: https://www.npmjs.com/package/safari-mcp
- **License**: MIT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a README entry for native macOS Safari automation (achiya-automation/safari-mcp) with GitHub link, noting wide tool coverage (~80 tools), preserved browser logins, lower overhead vs. Chrome, and macOS-only availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->