### PR TITLE
Add MCP Trust Kit to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ MCP servers for security operations, vulnerability scanning, and threat detectio
 - [PolicyLayer/Intercept](https://github.com/PolicyLayer/Intercept) 📇 🏠 🍎 🪟 🐧 - Open-source MCP proxy that enforces YAML policies on every tool call. Rate limiting, spending caps, argument validation, and full audit logging at the transport layer. Works with any MCP server.
 - [Sentinel-Gate/Sentinelgate](https://github.com/Sentinel-Gate/Sentinelgate) 🏎️ 🏠 🍎 🪟 🐧 - Open-source MCP proxy for AI agent access control. Intercepts every tool call with CEL policies, RBAC, full audit trail, content scanning, and Admin UI. Single binary, zero dependencies.
 - [prompt-security/clawsec](https://github.com/prompt-security/clawsec) 🐍 ☁️ - Security audit platform for AI agent skills and MCP servers. Five-tier detection pipeline (core rules, dynamic rules, LLM analysis, Firecracker sandbox, LLM review), continuous rule evolution, and automated vulnerability reports.
+- [aak204/MCP-Trust-Kit](https://github.com/aak204/MCP-Trust-Kit) 🐍 🏠 - Deterministic CI scanner and surface-risk scoring for MCP servers.
 
 ## CI/CD & DevOps Pipelines
 


### PR DESCRIPTION
Hi!

I'd like to suggest adding **MCP Trust Kit** to your awesome list.

It's an open-source, deterministic CI scanner that evaluates the surface risk (blast radius) of MCP servers before they are deployed to production. It checks for schema hygiene and flags dangerous capabilities (like filesystem mutation or shell execution).

-   Repo: https://github.com/aak204/MCP-Trust-Kit

Thank you for maintaining this valuable resource for the MCP community!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added MCP-Trust-Kit, a deterministic CI scanner with surface-risk scoring capabilities for MCP servers, to the Security section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->