### PR TITLE
Add Hindsight - AI agent memory by Vectorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Tools for persistent memory, context management, and knowledge retention for AI 
 - [mcpware/claude-code-organizer](https://github.com/mcpware/claude-code-organizer) 📇 🏠 - MCP server to organize Claude Code configurations — scan, move, delete memories, skills, MCP servers, and hooks across project and user scopes.
 - [omega-memory/omega-memory](https://github.com/omega-memory/omega-memory) 🐍 🏠 - Local-first persistent memory for AI agents. SQLite + ONNX embeddings, semantic search, auto-capture, checkpoint/resume. #1 on LongMemEval benchmark.
 - [SKULLFIRE07/cortex-memory](https://github.com/SKULLFIRE07/cortex-memory) 📇 🏠 - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. MIT licensed.
+- [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight) 🐍 🏠 ☁️ - State-of-the-art long-term memory for AI agents by Vectorize. Fully open-source MCP server with semantic search, auto-capture, and 15+ framework integrations. Self-hosted via `pip install hindsight-all` or optional cloud.
 
 ## Frameworks
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Tools for persistent memory, context management, and knowledge retention for AI 
 - [mcpware/claude-code-organizer](https://github.com/mcpware/claude-code-organizer) 📇 🏠 - MCP server to organize Claude Code configurations — scan, move, delete memories, skills, MCP servers, and hooks across project and user scopes.
 - [omega-memory/omega-memory](https://github.com/omega-memory/omega-memory) 🐍 🏠 - Local-first persistent memory for AI agents. SQLite + ONNX embeddings, semantic search, auto-capture, checkpoint/resume. #1 on LongMemEval benchmark.
 - [SKULLFIRE07/cortex-memory](https://github.com/SKULLFIRE07/cortex-memory) 📇 🏠 - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. MIT licensed.
-- [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight) 🐍 🏠 ☁️ - State-of-the-art long-term memory for AI agents by Vectorize. Fully open-source MCP server with semantic search, auto-capture, and 15+ framework integrations. Self-hosted via `pip install hindsight-all` or optional cloud.
+- [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight) 🐍 🏠 ☁️ - Long-term memory for AI agents by Vectorize. Fully open-source MCP server with semantic search, auto-capture, and 15+ framework integrations. Self-hosted via `pip install hindsight-all` or optional cloud.
 
 ## Frameworks
 


### PR DESCRIPTION
## Summary
- Adds [Hindsight](https://github.com/vectorize-io/hindsight) to the **🧠 Memory & Context** section under AI Agent Infrastructure
- Hindsight is a state-of-the-art, MIT-licensed open-source long-term memory system for AI agents by Vectorize
- Provides an MCP server with semantic search, auto-capture, and 15+ framework integrations (LangChain, CrewAI, Claude Code, etc.)
- Can run fully self-hosted via `pip install hindsight-all` (embedded server + DB) or with optional cloud

## Test plan
- [ ] Verify the entry follows the existing format (`[name](link) icons - Description`)
- [ ] Verify the link resolves to the correct GitHub repository
- [ ] Verify placement in the Memory & Context section is appropriate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added README entry for an AI Agent Infrastructure resource describing a fully open-source long-term memory server with semantic search, auto-capture, 15+ framework integrations, and installation/self-hosting instructions (including pip install) plus an optional cloud deployment reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->