### PR TITLE
Add Novyx MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Tools for persistent memory, context management, and knowledge retention for AI 
 
 - [mcpware/claude-code-organizer](https://github.com/mcpware/claude-code-organizer) 📇 🏠 - MCP server to organize Claude Code configurations — scan, move, delete memories, skills, MCP servers, and hooks across project and user scopes.
 - [omega-memory/omega-memory](https://github.com/omega-memory/omega-memory) 🐍 🏠 - Local-first persistent memory for AI agents. SQLite + ONNX embeddings, semantic search, auto-capture, checkpoint/resume. #1 on LongMemEval benchmark.
+- [novyxlabs/novyx-mcp](https://github.com/novyxlabs/novyx-mcp) 🐍 🏠 ☁️ - Persistent memory for AI agents with 107 tools: remember, recall, rollback, audit, knowledge graph, governed actions, eval, cortex, and Runtime v2 agent orchestration. Local SQLite (zero-config) or Novyx Cloud. Install via `uvx novyx-mcp`.
 - [SKULLFIRE07/cortex-memory](https://github.com/SKULLFIRE07/cortex-memory) 📇 🏠 - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. MIT licensed.
 
 ## Frameworks


### PR DESCRIPTION
Adds [Novyx MCP](https://github.com/novyxlabs/novyx-mcp) to the Memory & Context section under AI Agent Infrastructure.

Novyx MCP is a persistent memory server for AI agents with 107 tools covering remember, recall, rollback, audit, knowledge graph, governed actions, eval, cortex, and Runtime v2 agent orchestration. Runs locally with SQLite (zero-config) or connects to Novyx Cloud.

- GitHub: https://github.com/novyxlabs/novyx-mcp
- PyPI: https://pypi.org/project/novyx-mcp/
- License: MIT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry for the novyx-mcp MCP server in the "AI Agent Infrastructure" → "Memory & Context" section, including details on the server description, supported capabilities, available deployment modes (local SQLite and Novyx Cloud), and the installation instructions via uvx.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->