### PR TITLE
Add Database Management section with haymon-ai/database

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Tools for managing containers, Kubernetes clusters, and related orchestration pl
 - [thunderboltsid/mcp-nutanix](https://github.com/thunderboltsid/mcp-nutanix) 🏎️ 🏠/☁️ - Go-based MCP Server for interfacing with Nutanix Prism Central resources.
 - [arnstarn/mcp-server-spotinst](https://github.com/arnstarn/mcp-server-spotinst) 🐍 ☁️ - MCP server for Spot.io (Spotinst) API with 23 tools for managing Ocean clusters, VNGs, Elastigroups, costs, right-sizing, and logs across AWS and Azure with multi-account support.
 
+### 🗄️ Database Management
+Interact with SQL and NoSQL databases, execute queries, inspect schemas, and manage data.
+
+- [haymon-ai/database](https://github.com/haymon-ai/database) 🦀 🏠 - Single-binary MCP server for MySQL, MariaDB, PostgreSQL & SQLite with zero runtime dependencies.
+
 ### 🖥️ Command Line
 Run commands, capture output and otherwise interact with shells and command line tools.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Tools for managing containers, Kubernetes clusters, and related orchestration pl
 - [arnstarn/mcp-server-spotinst](https://github.com/arnstarn/mcp-server-spotinst) 🐍 ☁️ - MCP server for Spot.io (Spotinst) API with 23 tools for managing Ocean clusters, VNGs, Elastigroups, costs, right-sizing, and logs across AWS and Azure with multi-account support.
 
 ### 🗄️ Database Management
-Interact with SQL and NoSQL databases, execute queries, inspect schemas, and manage data.
+Interact with databases, execute queries, inspect schemas, and manage data.
 
 - [haymon-ai/database](https://github.com/haymon-ai/database) 🦀 🏠 - Single-binary MCP server for MySQL, MariaDB, PostgreSQL & SQLite with zero runtime dependencies.
 


### PR DESCRIPTION
Add a new Database Management section with Database MCP — a single-binary MCP server for MySQL, MariaDB, PostgreSQL & SQLite built in Rust with zero runtime dependencies.

- **URL**: https://github.com/haymon-ai/database
- **Website**: https://database.haymon.ai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Database Management" subsection describing database interaction (querying, schema inspection, data management).
  * Added a new MCP server listing for haymon-ai/database, describing a single-binary server supporting MySQL, MariaDB, PostgreSQL, and SQLite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->