### PR TITLE
Add tailscale-mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Tools for managing containers, Kubernetes clusters, and related orchestration pl
 - [cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) 🎖️ 📇 ☁️ - Integration with Cloudflare services including Workers, KV, R2, and D1.
 - [thunderboltsid/mcp-nutanix](https://github.com/thunderboltsid/mcp-nutanix) 🏎️ 🏠/☁️ - Go-based MCP Server for interfacing with Nutanix Prism Central resources.
 - [arnstarn/mcp-server-spotinst](https://github.com/arnstarn/mcp-server-spotinst) 🐍 ☁️ - MCP server for Spot.io (Spotinst) API with 23 tools for managing Ocean clusters, VNGs, Elastigroups, costs, right-sizing, and logs across AWS and Azure with multi-account support.
+- [YawLabs/tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) 📇 ☁️ — Manage Tailscale tailnets with 52 tools for devices, ACL policies, DNS, auth keys, users, webhooks, and audit logs.
 
 ### 🗄️ Database Management
 Interact with databases, execute queries, inspect schemas, and manage data.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Run commands, capture output and otherwise interact with shells and command line
 - [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server) - A secure shell command execution server implementing the Model Context Protocol (MCP)
 - [automateyournetwork/pyATS_MCP](https://github.com/automateyournetwork/pyATS_MCP) - Cisco pyATS server enabling structured, model-driven interaction with network devices.
 - [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 📇 🏠 🍎 🪟 🐧 - A swiss-army-knife that can manage/execute programs and read/write/search/edit code and text files.
+- [YawLabs/tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) 📇 ☁️ — Manage Tailscale tailnets with 52 tools for devices, ACL policies, DNS, auth keys, users, webhooks, and audit logs.
 
 ### 🔄 Version Control
 Interact with Git repositories and version control platforms. Enables repository management, code analysis, pull request handling, issue tracking, and other version control operations through standardized APIs.


### PR DESCRIPTION
[tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) is an open-source MCP server (MIT license) for managing Tailscale tailnets from AI assistants.

It provides 52 tools covering devices, ACL policies, DNS, auth keys, users, webhooks, and audit logs. Built with TypeScript, available on npm as `@yawlabs/tailscale-mcp`.

Added to the **Cloud Infrastructure > Cloud Providers > Other Cloud Platforms** section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new entry under Cloud Providers → Other Cloud Platforms describing a Tailscale management MCP server (YawLabs/tailscale-mcp). The entry lists available management tools covering devices, ACL policies, DNS, auth keys, users, webhooks, and audit logs, and notes a comprehensive toolset (52 tools) for tailnet administration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-devops-mcp-servers/pull/151)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->