### PR TITLE
Add lazymac/mcp and lazymac/k-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ Web content access and automation capabilities. Enables searching, scraping, and
 Tools for analyzing and managing project dependencies across build systems.
 
 - [arvindand/maven-tools-mcp](https://github.com/arvindand/maven-tools-mcp) ☕ ☁️ 🏠 🍎 🪟 🐧 - Universal Maven Central dependency intelligence for JVM build tools (Maven, Gradle, SBT, Mill). Provides version lookups, dependency health checks, age analysis, release patterns, and upgrade guidance with Context7 integration.
+- [lazymac/mcp](https://github.com/lazymac2x/lazymac-mcp) — Unified MCP server exposing 42+ developer tools (qr, ip-geo, ai-cost, llm-router, k-privacy, korean-nlp) backed by Cloudflare Workers. `npx -y @lazymac/mcp`
+- [lazymac/k-mcp](https://github.com/lazymac2x/lazymac-k-mcp) — Korean wedge MCP — PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP. `npx -y @lazymac/k-mcp`
 - [lunacompsia-oss/mcp-server-changelog](https://github.com/lunacompsia-oss/mcp-server-changelog) 📇 ☁️ 🏠 🍎 🪟 🐧 - Fetch and parse changelogs, release notes, and breaking changes from npm, PyPI, crates.io, and GitHub repositories.
 - [lunacompsia-oss/mcp-server-deps](https://github.com/lunacompsia-oss/mcp-server-deps) 📇 ☁️ 🏠 🍎 🪟 🐧 - Analyze dependency trees, check for vulnerabilities via OSV.dev, and audit outdated packages across npm, PyPI, and crates.io.
 - [lunacompsia-oss/mcp-server-license](https://github.com/lunacompsia-oss/mcp-server-license) 📇 ☁️ 🏠 🍎 🪟 🐧 - Check license types, SPDX compliance, compatibility matrices, and risk classification for open-source dependencies.


### PR DESCRIPTION
## What

- **`@lazymac/mcp`** — unified MCP server exposing 42 developer tools backed by api.lazy-mac.com (Cloudflare Workers, sub-200ms p95). Free 100/day tier.
- **`@lazymac/k-mcp`** — Korean wedge MCP for PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP.

## Why

Most MCP servers expose 1-3 tools. `lazymac/mcp` aggregates 42 tools through one install.

## Links

- npm: https://www.npmjs.com/package/@lazymac/mcp
- npm: https://www.npmjs.com/package/@lazymac/k-mcp
- Smithery: https://smithery.ai/server/lazymac/mcp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new entries to the build tools and dependency management documentation, highlighting additional MCP server implementations available for integration with their respective installation methods and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->