### PR TITLE
Add Helium MCP (remote news, markets, options)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 - [askbudi/roundtable](https://github.com/askbudi/roundtable) 🐍 🏠 - Zero-configuration MCP server that unifies multiple AI coding assistants (Codex, Claude Code, Cursor, Gemini) through intelligent auto-discovery and standardized interface.
 - [Composiohq/Rube](https://github.com/composiohq/rube) - Rube is an MCP server built on the Composio integration platform. It connects your AI tools to 500+ apps.
+- [connerlambden/helium-mcp](https://github.com/connerlambden/helium-mcp) 📇 ☁️ - Remote MCP server for real-time news intelligence with bias scoring (3.2M+ articles, 5000+ sources, 15+ dimensions), financial market data (stocks, ETFs, crypto, AI bull/bear cases), ML options pricing (probability ITM, Greeks, fair value), balanced news synthesis, trending topics, and meme search. [Documentation](https://heliumtrades.com/mcp-page/).
 - [julien040/anyquery](https://github.com/julien040/anyquery) 🏎️ 🏠 ☁️ - Query more than 40 apps with one binary using SQL. It can also connect to your PostgreSQL, MySQL, or SQLite compatible database. Local-first and private by design.
 - [metatool-ai/metatool-app](https://github.com/metatool-ai/metatool-app) 📇 ☁️ 🏠 🍎 🪟 🐧 - MetaMCP is the one unified middleware MCP server that manages your MCP connections with GUI.
 - [mindsdb/mindsdb](https://github.com/mindsdb/mindsdb) - Connect and unify data across various platforms and databases with [MindsDB as a single MCP server](https://docs.mindsdb.com/mcp/overview).


### PR DESCRIPTION
## Summary

Adds **[Helium MCP](https://github.com/connerlambden/helium-mcp)** to the **Aggregators** section of the README.

Helium MCP is a **remote** Model Context Protocol server that exposes multiple tool domains through one endpoint: real-time news with bias scoring (3.2M+ articles, 5000+ sources, 15+ dimensions), stock/ETF/crypto data (including AI bull/bear cases), ML options pricing (probability ITM, Greeks, fair value), balanced news synthesis, trending topics, and meme search.

- **Repository:** https://github.com/connerlambden/helium-mcp  
- **Documentation:** https://heliumtrades.com/mcp-page/

## Checklist

- [x] Follows the existing README list format (`[org/repo](url) 📇 ☁️ - description`).
- [x] Uses 📇 for the JavaScript codebase and ☁️ for the remote service, per the legend.

Thanks for maintaining this list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated aggregators documentation with a new entry, including details about its capabilities for remote news, market, and machine learning features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->