### PR TITLE
Add wp-cli-mcp — WordPress management via WP-CLI (57+ tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Run commands, capture output and otherwise interact with shells and command line
 - [automateyournetwork/pyATS_MCP](https://github.com/automateyournetwork/pyATS_MCP) - Cisco pyATS server enabling structured, model-driven interaction with network devices.
 - [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 📇 🏠 🍎 🪟 🐧 - A swiss-army-knife that can manage/execute programs and read/write/search/edit code and text files.
 
+### 🌐 CMS & Web Platforms
+
+- [mvtandas/wp-cli-mcp](https://github.com/mvtandas/wp-cli-mcp) [![mvtandas/wp-cli-mcp MCP server](https://glama.ai/mcp/servers/mvtandas/wp-cli-mcp/badges/score.svg)](https://glama.ai/mcp/servers/mvtandas/wp-cli-mcp) 📇 🏠 - Full WordPress management via WP-CLI with 57+ tools. Themes (install/edit files), plugins, posts, WooCommerce (products/orders/coupons), menus, users, database, scaffolding, maintenance mode, and PHP eval. Works locally or over SSH.
+
 ### 🔄 Version Control
 Interact with Git repositories and version control platforms. Enables repository management, code analysis, pull request handling, issue tracking, and other version control operations through standardized APIs.
 


### PR DESCRIPTION
Adds [wp-cli-mcp](https://github.com/mvtandas/wp-cli-mcp) under a new **CMS & Web Platforms** section.

57+ MCP tools for full WordPress management:
- **Themes**: install, activate, file read/write/delete (edit templates directly)
- **Plugins**: install, activate, deactivate, delete, search
- **Posts**: CRUD for any post type + post meta management
- **WooCommerce**: products, orders, coupons, pricing
- **Menus, Users, Media, Taxonomies, Widgets**
- **Database**: query, export, search-replace
- **Scaffold**: theme, plugin, Gutenberg block
- **Maintenance**: mode toggle, cache flush, cron management
- **PHP eval**: execute any WordPress PHP code

Published on npm (`wp-cli-mcp`). Already listed on [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) and [Glama](https://glama.ai/mcp/servers/mvtandas/wp-cli-mcp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "CMS & Web Platforms" section to the README documenting a WordPress management tool that provides capabilities for managing themes, plugins, posts, WooCommerce, menus, users, and database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->