### PR TITLE
Add Not Human Search and AI Dev Jobs MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,10 @@ Tools for managing projects, issues, and workflows.
 MCP servers for discovering tools, APIs, and services for AI agents.
 
 - [unitedideas/nothumansearch](https://github.com/unitedideas/nothumansearch) 🏎️ ☁️ - MCP server for discovering agent-first tools. Indexes 1,400+ sites with agentic readiness scores. Tools: search_agents, get_site_details, verify_mcp.
+
+### 💼 Job & Career Search
+MCP servers for searching job listings and career opportunities.
+
 - [unitedideas/aidevboard-mcp](https://github.com/unitedideas/aidevboard-mcp) 📇 ☁️ - MCP server for AI/ML job search across 5,000+ curated roles. Tools: search_jobs, get_job, list_companies, match_jobs.
 
 ## AI Agent Infrastructure

--- a/README.md
+++ b/README.md
@@ -310,6 +310,14 @@ Tools for managing projects, issues, and workflows.
 - [nguyenvanduocit/jira-mcp](https://github.com/nguyenvanduocit/jira-mcp) 🏎️ ☁️ - A Go-based MCP connector for Jira that enables AI assistants like Claude to interact with Atlassian Jira. This tool provides a seamless interface for AI models to perform common Jira operations including issue management, sprint planning, and workflow transitions.
 - [sooperset/mcp-atlassian](https://github.com/sooperset/mcp-atlassian) 🐍 ☁️ - MCP server for Atlassian products (Confluence and Jira). Supports Confluence Cloud, Jira Cloud, and Jira Server/Data Center. Provides comprehensive tools for searching, reading, creating, and managing content across Atlassian workspaces.
 
+## Search & Discovery
+
+### 🔍 Tool & Service Discovery
+MCP servers for discovering tools, APIs, and services for AI agents.
+
+- [unitedideas/nothumansearch](https://github.com/unitedideas/nothumansearch) 🏎️ ☁️ - MCP server for discovering agent-first tools. Indexes 1,400+ sites with agentic readiness scores. Tools: search_agents, get_site_details, verify_mcp.
+- [unitedideas/aidevboard-mcp](https://github.com/unitedideas/aidevboard-mcp) 📇 ☁️ - MCP server for AI/ML job search across 5,000+ curated roles. Tools: search_jobs, get_job, list_companies, match_jobs.
+
 ## AI Agent Infrastructure
 
 ### 🧠 Memory & Context


### PR DESCRIPTION
## Added MCP Servers

### Not Human Search MCP
- **Repo:** https://github.com/unitedideas/nothumansearch
- **Description:** MCP server for discovering agent-first tools. Indexes 1,400+ sites with agentic readiness scores.
- **Tools:** search_agents, get_site_details, verify_mcp
- **Language:** Go
- **Scope:** Cloud service

### AI Dev Jobs MCP  
- **Repo:** https://github.com/unitedideas/aidevboard-mcp
- **Description:** MCP server for AI/ML job search across 5,000+ curated roles.
- **Tools:** search_jobs, get_job, list_companies, match_jobs
- **Language:** TypeScript
- **Scope:** Cloud service

**Placement:** Added under a new "Search & Discovery" section, as these servers enable AI agents to discover tools and job listings - a capability not covered by existing sections.

Both servers are listed in the official MCP registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Search & Discovery" section to the README with two subsections: "Tool & Service Discovery" and "Job & Career Search", listing newly documented discovery and job-search services and their available operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->