### PR TITLE
Add Chain.Love MCP to the list of resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Servers for accessing many apps and tools through a single MCP server.
 - [Arch Tools](https://archtools.dev) ☁️ - 53 production-ready AI tools via MCP with x402 USDC payments. Web scraping, crypto data, AI generation, OCR, and more.
 - [pumanitro/global-chat](https://github.com/pumanitro/global-chat) 📇 ☁️ - Cross-protocol AI agent discovery MCP server. Searchable directory of 18K+ MCP servers across 6+ registries (mcp.so, Glama, Smithery, PulseMCP), with agents.txt validation and protocol-agnostic agent search.
 - [uAI-solana/useful-ai-mcp](https://github.com/uAI-solana/useful-ai-mcp) 📇 ☁️ - Fully dynamic MCP server exposing 200+ shared utility tools for AI agents. Tool list updates automatically based on real usage data. No auth required.
+- [Chain.Love MCP](https://github.com/Chain-Love/chain.love-mcp) 📇 ☁️ - Hosted MCP gateway that enables AI agents to discover and compare Web3 infra services (RPCs, indexing, oracles, storage, compute, dev tools, and more) across 50+ networks via a single endpoint.
 
 ### 📂 Browser Automation
 Web content access and automation capabilities. Enables searching, scraping, and processing web content in AI-friendly formats.


### PR DESCRIPTION
## What this adds

Adds Chain.Love MCP.

## Entry

- [Chain.Love MCP](https://github.com/Chain-Love/chain.love-mcp) - Hosted MCP gateway that enables AI agents to discover and compare Web3 infra services (RPCs, indexing, oracles, storage, compute, dev tools, and more) across 50+ networks via a single endpoint.

## Additional links

- Landing page: https://www.chain.love/mcp-gateway
- Documentation: https://chain-love.gitbook.io/mcp-module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about Chain.Love MCP, a Web3 infrastructure gateway for discovering and comparing services such as RPCs, indexing, oracles, storage, and compute tools across 50+ networks through a single endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->