### PR TITLE
Add SLM MCP Hub (Gateways) + SuperLocalMemory (Memory & Context)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ Tools for persistent memory, context management, and knowledge retention for AI 
 - [mcpware/claude-code-organizer](https://github.com/mcpware/claude-code-organizer) 📇 🏠 - MCP server to organize Claude Code configurations — scan, move, delete memories, skills, MCP servers, and hooks across project and user scopes.
 - [omega-memory/omega-memory](https://github.com/omega-memory/omega-memory) 🐍 🏠 - Local-first persistent memory for AI agents. SQLite + ONNX embeddings, semantic search, auto-capture, checkpoint/resume. #1 on LongMemEval benchmark.
 - [SKULLFIRE07/cortex-memory](https://github.com/SKULLFIRE07/cortex-memory) 📇 🏠 - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. MIT licensed.
+- [qualixar/superlocalmemory](https://github.com/qualixar/superlocalmemory) 🐍 📇 🏠 - Persistent agent memory with 6-channel retrieval (semantic, BM25, temporal, Hopfield, spreading activation, entity graph). Fisher-Rao geometry, zero-cloud, EU AI Act compliant. 16K+ monthly downloads. Beats Mem0 (74.8% vs 64.2% on LoCoMo). 3 arXiv papers.
+
+### 🔌 Gateways & Federation
+Universal MCP gateways that aggregate multiple MCP servers into a single endpoint.
+
+- [qualixar/slm-mcp-hub](https://github.com/qualixar/slm-mcp-hub) 🐍 📇 🏠 - Universal MCP gateway that federates 430+ tools from 37 servers through one endpoint. 75% RAM reduction, background startup, auto-retry, cost tracking. Dual Python + Node. `pip install slm-mcp-hub` or `npm install slm-mcp-hub`.
 
 ## Frameworks
 


### PR DESCRIPTION
Adding 2 open-source DevOps-relevant MCP tools from [Qualixar](https://qualixar.com):

1. **[SLM MCP Hub](https://github.com/qualixar/slm-mcp-hub)** — Universal gateway that federates 430+ tools from 37 MCP servers through one endpoint. Perfect for DevOps teams managing multiple MCPs at scale. (New subsection: Gateways & Federation)
2. **[SuperLocalMemory](https://github.com/qualixar/superlocalmemory)** — Persistent agent memory with 6-channel retrieval. 16K+ monthly downloads, 3 arXiv papers. (Added to Memory & Context)

Both are part of the [Qualixar AI Agent Reliability Platform](https://qualixar.com) — 7 OSS products, 19K+ monthly downloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Memory & Context" documentation for superlocalmemory.
  * Introduced new "Gateways & Federation" section describing universal MCP gateways.
  * Added MCP server entry with installation commands for Python and Node environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->