### PR TITLE
Add Uptrack uptime monitoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Tools for monitoring application performance and infrastructure health.
 - [willibrandon/CursorMCPMonitor](https://github.com/willibrandon/CursorMCPMonitor) #️⃣ 🏠 - Real-time monitoring tool for Model Context Protocol interactions in Cursor AI editor. Track, analyze, and debug AI context exchanges.
 - [Polar Signals Remote MCP](https://www.polarsignals.com/blog/posts/2025/07/17/the-mcp-for-performance-engineering) 🐍 ☁️ - MCP server for Polar Signals Cloud continuous profiling platform, enabling AI assistants to analyze CPU performance, memory usage, and identify optimization opportunities in production systems.
 - [unitedideas/resolve-mcp](https://github.com/unitedideas/resolve-mcp) 🐍 ☁️ - Structured error recovery for AI agents. Returns resolution playbooks with backoff schedules, retry strategies, and recovery steps for 20+ services (OpenAI, Anthropic, Stripe, AWS, Postgres, Redis, Twilio, etc.). Complements monitoring tools by telling agents how to recover from errors, not just detect them.
+- [Uptrack-App/uptrack-mcp](https://github.com/Uptrack-App/uptrack-mcp) 📇 ☁️ - Uptime monitoring MCP server. 10 tools for listing/creating/pausing monitors and acknowledging incidents. Remote Streamable-HTTP at `api.uptrack.app/mcp` (OAuth 2.0) or stdio via `npx @uptrack-app/mcp`.
 - [nicofains1/agentwatch](https://github.com/nicofains1/agentwatch) 📇 🏠 - Multi-agent observability for cascade failure detection, fleet-wide heartbeat monitoring, and forensic replay. Works as an npm library or MCP server.
 
 ## Project & Service Management


### PR DESCRIPTION
Adds [Uptrack-App/uptrack-mcp](https://github.com/Uptrack-App/uptrack-mcp) to Application Performance Monitoring.

Uptrack is uptime/SLA monitoring (HTTP, TCP, DNS, SSL, ping, heartbeat). The MCP server gives AI agents 10 tools for monitor + incident management:
- list/get/create/update/pause/resume/delete monitor
- list/get/acknowledge incident

**Transports**:
- Remote Streamable-HTTP at `https://api.uptrack.app/mcp` with OAuth 2.0 + PKCE — works with Claude.ai, ChatGPT, Cursor, VS Code, Windsurf
- Stdio via `npx @uptrack-app/mcp` (API key) — for Claude Desktop, CI

Published under MIT on [npm](https://www.npmjs.com/package/@uptrack-app/mcp) and [GitHub](https://github.com/Uptrack-App/uptrack-mcp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added entry to the Monitoring & Observability section documenting an uptime monitoring tool with capabilities for monitor lifecycle management and incident acknowledgment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->