### PR TITLE
Add Qovery MCP Server to Other Cloud Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Tools for managing containers, Kubernetes clusters, and related orchestration pl
 - [cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) 🎖️ 📇 ☁️ - Integration with Cloudflare services including Workers, KV, R2, and D1.
 - [thunderboltsid/mcp-nutanix](https://github.com/thunderboltsid/mcp-nutanix) 🏎️ 🏠/☁️ - Go-based MCP Server for interfacing with Nutanix Prism Central resources.
 - [arnstarn/mcp-server-spotinst](https://github.com/arnstarn/mcp-server-spotinst) 🐍 ☁️ - MCP server for Spot.io (Spotinst) API with 23 tools for managing Ocean clusters, VNGs, Elastigroups, costs, right-sizing, and logs across AWS and Azure with multi-account support.
+- [Qovery/qovery-mcp-server](https://mcp.qovery.com/mcp) 🏎️ ☁️ - Enterprise Kubernetes management via MCP. Deploy and manage applications, databases, Helm charts, and Terraform modules on AWS EKS, GCP GKE, Azure AKS, and Scaleway. Query environments, troubleshoot deployments, monitor infrastructure. [Docs](https://www.qovery.com/docs/copilot/mcp-server). Also has an [AI Agent Skill](https://github.com/Qovery/qovery-skills) for deploying from Claude Code, Cursor, and 30+ tools.
 
 ### 🗄️ Database Management
 Interact with databases, execute queries, inspect schemas, and manage data.


### PR DESCRIPTION
Adds [Qovery MCP Server](https://mcp.qovery.com/mcp) — enterprise Kubernetes management via MCP. Deploy and manage applications, databases, Helm charts, and Terraform modules on AWS EKS, GCP GKE, Azure AKS, and Scaleway through natural language.

- MCP Server: https://mcp.qovery.com/mcp
- Documentation: https://www.qovery.com/docs/copilot/mcp-server
- Also has an AI Agent Skill: https://github.com/Qovery/qovery-skills
- Website: https://www.qovery.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Qovery MCP Server reference documenting enterprise Kubernetes management for AWS EKS, GCP GKE, Azure AKS, and Scaleway environments, including application and database deployment, Helm chart management, and environment monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->