### PR TITLE
Add AgentSeal to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ MCP servers for security operations, vulnerability scanning, and threat detectio
 - [PolicyLayer/Intercept](https://github.com/PolicyLayer/Intercept) 📇 🏠 🍎 🪟 🐧 - Open-source MCP proxy that enforces YAML policies on every tool call. Rate limiting, spending caps, argument validation, and full audit logging at the transport layer. Works with any MCP server.
 - [Sentinel-Gate/Sentinelgate](https://github.com/Sentinel-Gate/Sentinelgate) 🏎️ 🏠 🍎 🪟 🐧 - Open-source MCP proxy for AI agent access control. Intercepts every tool call with CEL policies, RBAC, full audit trail, content scanning, and Admin UI. Single binary, zero dependencies.
 - [prompt-security/clawsec](https://github.com/prompt-security/clawsec) 🐍 ☁️ - Security audit platform for AI agent skills and MCP servers. Five-tier detection pipeline (core rules, dynamic rules, LLM analysis, Firecracker sandbox, LLM review), continuous rule evolution, and automated vulnerability reports.
+- [JoeyBrar/agentseal-mcp](https://github.com/JoeyBrar/agentseal-mcp) 📇 🏠 - Action logs for AI agents. Records every action in a SHA-256 hash chain, for verifiable audit trails. Install via `npx agentseal-mcp`.
 
 ## CI/CD & DevOps Pipelines
 


### PR DESCRIPTION
Adds [AgentSeal](https://github.com/JoeyBrar/agentseal-mcp) to the Security section.

AgentSeal is an MCP server that records every agent action in a SHA-256 hash chain, producing a verifiable audit trail for AI agents.

Install: `npx agentseal-mcp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new security-focused MCP server for action logs using SHA-256 hash chain authentication, installable via npx.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->