### PR TITLE
Add GeiserX/spinnaker-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ MCP servers for security operations, vulnerability scanning, and threat detectio
 ### 🔄 Continuous Integration
 Tools for automating the integration of code changes and running tests.
 
+- [GeiserX/spinnaker-mcp](https://github.com/GeiserX/spinnaker-mcp) 🏎️ ☁️ - A Go-based MCP server that bridges any Spinnaker continuous delivery instance via the Gate API, exposing 37 tools for application management, pipeline operations, execution control, and infrastructure queries.
 - [Tiberriver256/mcp-server-github-actions](https://github.com/Tiberriver256/mcp-server-github-actions) 📇 ☁️ - MCP server for interacting with GitHub Actions workflows, enabling AI assistants to manage CI/CD pipelines.
 - [lobehub/mcp-hello-world](https://github.com/lobehub/mcp-hello-world) 📇 ☁️ - A simple Hello World MCP server for CI/CD test.
 


### PR DESCRIPTION
Adds [spinnaker-mcp](https://github.com/GeiserX/spinnaker-mcp) — a Go-based MCP server for Spinnaker continuous delivery platform management (37 tools covering applications, pipelines, executions, and infrastructure via the Gate API).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to include a new MCP server for Spinnaker continuous integration. The entry provides the repository link and describes the server's Go-based integration with Spinnaker's Gate API, detailing the tools and capabilities it exposes for seamless Spinnaker integration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->