### PR TITLE
Add EnigmAgent MCP - encrypted AI credential vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Interact with Git repositories and version control platforms. Enables repository
 
 ### 🔒 Security
 MCP servers for security operations, vulnerability scanning, and threat detection.
+- [EnigmAgent MCP](https://github.com/Agnuxo1/EnigmAgent/tree/main/platforms/mcp-server) - Encrypted local vault for AI agents. Resolve {{SECRET}} placeholders in prompts without exposing real values. AES-256-GCM + Argon2id. `enigmagent-mcp`
 
 - [LaurieWired/GhidraMCP](https://github.com/LaurieWired/GhidraMCP) ☕ 🏠 - A Model Context Protocol server for Ghidra that enables LLMs to autonomously reverse engineer applications. Provides tools for decompiling binaries, renaming methods and data, and listing methods, classes, imports, and exports.
 - [13bm/GhidraMCP](https://github.com/13bm/GhidraMCP) 🐍 ☕ 🏠 - MCP server for integrating Ghidra with AI assistants. This plugin enables binary analysis, providing tools for function inspection, decompilation, memory exploration, and import/export analysis via the Model Context Protocol.


### PR DESCRIPTION
EnigmAgent provides encrypted local credential storage for AI agents. Agents use `{{PLACEHOLDER}}` references instead of real secrets. The MCP server (`enigmagent-mcp`) enables any MCP-compatible AI to resolve secrets from the encrypted vault. AES-256-GCM + Argon2id. https://github.com/Agnuxo1/EnigmAgent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added EnigmAgent MCP as a new entry to the Security-focused MCP server list, including repository reference and overview of encrypted secret handling and prompt placeholder resolution features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->