### PR TITLE
Add EnigmAgent — AES-256-GCM encrypted credential vault for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ MCP servers for security operations, vulnerability scanning, and threat detectio
 - [PolicyLayer/Intercept](https://github.com/PolicyLayer/Intercept) 📇 🏠 🍎 🪟 🐧 - Open-source MCP proxy that enforces YAML policies on every tool call. Rate limiting, spending caps, argument validation, and full audit logging at the transport layer. Works with any MCP server.
 - [Sentinel-Gate/Sentinelgate](https://github.com/Sentinel-Gate/Sentinelgate) 🏎️ 🏠 🍎 🪟 🐧 - Open-source MCP proxy for AI agent access control. Intercepts every tool call with CEL policies, RBAC, full audit trail, content scanning, and Admin UI. Single binary, zero dependencies.
 - [prompt-security/clawsec](https://github.com/prompt-security/clawsec) 🐍 ☁️ - Security audit platform for AI agent skills and MCP servers. Five-tier detection pipeline (core rules, dynamic rules, LLM analysis, Firecracker sandbox, LLM review), continuous rule evolution, and automated vulnerability reports.
+- [Agnuxo1/EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) 📇 🏠 🍎 🪟 🐧 - AES-256-GCM + Argon2id encrypted local vault for AI agent credentials. Resolves `{{PLACEHOLDER}}` secrets at runtime so API keys never appear in prompts, logs, or LLM context. Dual-mode: stdio MCP server or REST API on port 3737.
 
 ## CI/CD & DevOps Pipelines
 


### PR DESCRIPTION
## EnigmAgent — Encrypted Local Vault for AI Agent Credentials

**Repository:** https://github.com/Agnuxo1/EnigmAgent  
**npm:** `enigmagent-mcp` (v1.0.0)

### Security Features
- **AES-256-GCM** authenticated encryption (prevents ciphertext tampering)
- **Argon2id** key derivation (memory-hard, resists GPU/ASIC brute-force)
- **`{{PLACEHOLDER}}` token resolution** — API keys injected at runtime, LLM never sees actual credentials
- **Domain binding** — secrets scoped to specific calling origins
- **Zero-knowledge** — master password never stored; vault key derived on unlock
- **Local-only** — no cloud sync, no telemetry

Works as both MCP server (stdio) and REST API (port 3737). Compatible with Claude Desktop, n8n, Cursor, and all MCP clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new MCP server listing to the Security section of the README, including details about encrypted credential management, runtime secret resolution, and availability through multiple API interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->