### PR TITLE
Add Bernstein

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Tools for testing, fault injection, and resilience validation.
 ### 🤖 Coding Agents
 Full coding agents that enable LLMs to read, edit, and execute code and solve general programming tasks completely autonomously.
 
+- [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) 🐍 🏠 - Multi-agent orchestrator with MCP server mode. Spawns parallel AI coding agents in git worktrees, routes to optimal models, verifies via quality gates. 21 CLI adapters, deterministic scheduling.
 - [bgauryy/octocode-mcp](https://github.com/bgauryy/octocode-mcp) ☁️ 📇 🍎 🪟 🐧 - AI-powered developer assistant that enables advanced research, analysis and discovery across GitHub ecosystem
 - [oraios/serena](https://github.com/oraios/serena) 🐍🏠 - A fully-featured coding agent that relies on symbolic code operations by using language servers.
 - [ezyang/codemcp](https://github.com/ezyang/codemcp) 🐍🏠 - Coding agent with basic read, write and command line tools.


### PR DESCRIPTION
Re-opens #165 with the canonical `https://github.com/sipyourdrink-ltd/bernstein` URL after the project transferred from my personal account to the @sipyourdrink-ltd organization. Same content as the previous PR, only the GitHub URL was updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Bernstein to the Coding Agents catalog with a repository link and capability summary describing MCP server‑mode multi‑agent orchestration: spawning parallel coding agents in git worktrees, routing to optimal models, verification via quality gates, support for 21 CLI adapters, and deterministic scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->