### PR TITLE
Add Vigil MCPWatch under Application Performance Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Tools for managing alerts and notifications in monitoring systems.
 ### 🔍 Application Performance Monitoring
 Tools for monitoring application performance and infrastructure health.
 
+- [AlexlaGuardia/Vigil](https://github.com/AlexlaGuardia/Vigil) 🐍 ☁️/🏠 - MCPWatch instruments any Python MCP server in one line — FastMCP and low-level Server, same API. Per-tool latency (p50/p95/p99), error rates, silent-failure detection, and call-volume tracking. REST API, CLI, alerts. MIT.
 - [alilxxey/openobserve-community-mcp](https://github.com/alilxxey/openobserve-community-mcp) 🐍 🏠 - MCP server for OpenObserve Community Edition via REST API. Read-only tools for searching logs, traces, stream schemas, and dashboards without requiring the Enterprise license.
 - [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) 📇 ☁️ - MCP server for Dynatrace Observability monitoring, providing AI-powered insights into application performance and infrastructure health.
 - [ingero-io/ingero](https://github.com/ingero-io/ingero) 🏎️ 🏠 - eBPF-based GPU causal observability agent with MCP server, providing AI assistants with causal chains explaining GPU latency from CUDA Runtime/Driver API tracing and host kernel event tracing.


### PR DESCRIPTION
Adds **Vigil MCPWatch** under `Monitoring & Observability → Application Performance Monitoring`.

MCPWatch is observability for MCP servers themselves. One line wraps any Python MCP server — both `FastMCP` and the low-level `mcp.server.lowlevel.Server` — and tracks:

- Tool call latency (p50/p95/p99)
- Per-tool error rates
- Silent failures (empty/null returns + `isError` responses)
- Call volume over time

Used in production across 95+ MCP tools. MIT, no config required. REST API, CLI, and alert hooks included.

- Repo: https://github.com/AlexlaGuardia/Vigil
- PyPI: https://pypi.org/project/vigil-agent/
- Article: https://dev.to/alexlaguardia/your-mcp-servers-are-flying-blind-heres-how-to-fix-it-3g51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Vigil to the Application Performance Monitoring section—a monitoring tool for Python MCP servers with latency tracking, error monitoring, and alerting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->