### PR TITLE
Add nylas/cli under Command Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Run commands, capture output and otherwise interact with shells and command line
 - [g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands) 📇 🏠 - Run any command with `run_command` and `run_script` tools.
 - [maxim-saplin/mcp_safe_local_python_executor](https://github.com/maxim-saplin/mcp_safe_local_python_executor) - Safe Python interpreter based on HF Smolagents `LocalPythonExecutor`
 - [MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server) 🐍 🏠 - Command line interface with secure execution and customizable security policies
+- [nylas/cli](https://github.com/nylas/cli) 🏎️ ☁️ 🍎 🪟 🐧 - Email, calendar, and contacts CLI with built-in MCP server. 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP. One auth, JSON output for scripting, install via `nylas mcp install`. Docs: https://cli.nylas.com
 - [claw-army/claude-node](https://github.com/claw-army/claude-node) 🐍 - Python subprocess bridge for Claude Code CLI, giving Python code direct access to Claude Code native capabilities via stream-json.
 - [OthmaneBlial/term_mcp_deepseek](https://github.com/OthmaneBlial/term_mcp_deepseek) 🐍 🏠 - A DeepSeek MCP-like Server for Terminal
 - [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server) - A secure shell command execution server implementing the Model Context Protocol (MCP)


### PR DESCRIPTION
Adds nylas/cli to the Command Line section.

**What it is:** Email, calendar, and contacts CLI built in Go, with a built-in MCP server. 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP.

**Why Command Line:** It's a CLI primitive for terminal-based email/calendar workflows — fits alongside iterm-mcp, mcp-server-commands, and DesktopCommanderMCP.

**Icons:** 🏎️ (Go) ☁️ (Cloud) 🍎 🪟 🐧 (cross-platform)

**Source:** https://github.com/nylas/cli  
**Docs:** https://cli.nylas.com  
**Install:** `brew install nylas/nylas-cli/nylas` then `nylas mcp install`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about the Command Line MCP server for nylas/cli, including installation instructions and documentation link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->