### PR TITLE
Add NotFair (Google Ads MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Tools for analyzing and managing project dependencies across build systems.
 - [lunacompsia-oss/mcp-server-deps](https://github.com/lunacompsia-oss/mcp-server-deps) 📇 ☁️ 🏠 🍎 🪟 🐧 - Analyze dependency trees, check for vulnerabilities via OSV.dev, and audit outdated packages across npm, PyPI, and crates.io.
 - [lunacompsia-oss/mcp-server-license](https://github.com/lunacompsia-oss/mcp-server-license) 📇 ☁️ 🏠 🍎 🪟 🐧 - Check license types, SPDX compliance, compatibility matrices, and risk classification for open-source dependencies.
 - [tersePrompts/jarp-mcp](https://github.com/tersePrompts/jarp-mcp) 📇 ☕ 🏠 - Java Archive Reader Protocol - MCP server that gives AI agents X-ray vision into compiled Java code. Enables decompiling and analyzing Java classes directly from Maven/Gradle dependencies using bundled CFR decompiler with zero-setup installation.
+- [nowork-studio/toprank](https://github.com/nowork-studio/toprank) - **NotFair** Google Ads MCP server. Connect Claude and AI agents to a Google Ads account: diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API. Free tier available.
 
 ## Monitoring & Observability
 


### PR DESCRIPTION
Adding NotFair under Build Tools & Dependency Management. It's a Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Source: github.com/nowork-studio/toprank
Registry: io.github.nowork-studio/notfair (active in the official MCP registry)
Endpoint: streamable-http at notfair.co/api/mcp/google_ads

Free tier available. Happy to adjust the format if you'd prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added NotFair/toprank, a new Google Ads MCP server resource, to the Build Tools & Dependency Management section. This tool enables AI agents to establish secure connections with Google Ads accounts, diagnose campaign performance issues, generate actionable optimization recommendations, and execute approved changes directly through the Google Ads API.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-devops-mcp-servers/pull/202)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->