### PR TITLE
Add dakera-mcp to Memory & Context section

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Tools for managing projects, issues, and workflows.
 ### 🧠 Memory & Context
 Tools for persistent memory, context management, and knowledge retention for AI agents.
 
+- [dakera-ai/dakera-mcp](https://github.com/dakera-ai/dakera-mcp) 🦀 🏠 🍎 🪟 🐧 - Self-hosted MCP-native agent memory server. 83 tools for persistent, decay-weighted episodic memory across sessions. RocksDB + HNSW, 87.8% LoCoMo benchmark. Docker Compose deployment, multi-SDK support.
 - [mcpware/claude-code-organizer](https://github.com/mcpware/claude-code-organizer) 📇 🏠 - MCP server to organize Claude Code configurations — scan, move, delete memories, skills, MCP servers, and hooks across project and user scopes.
 - [omega-memory/omega-memory](https://github.com/omega-memory/omega-memory) 🐍 🏠 - Local-first persistent memory for AI agents. SQLite + ONNX embeddings, semantic search, auto-capture, checkpoint/resume. #1 on LongMemEval benchmark.
 - [SKULLFIRE07/cortex-memory](https://github.com/SKULLFIRE07/cortex-memory) 📇 🏠 - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. MIT licensed.


### PR DESCRIPTION
## dakera-mcp

[dakera-mcp](https://github.com/dakera-ai/dakera-mcp) is a self-hosted MCP-native agent memory server that provides persistent, decay-weighted memory for AI agents used in DevOps workflows.

**Why Memory & Context section:**
- Gives DevOps AI agents persistent memory of runbook procedures, incident patterns, and operational decisions across sessions
- 83 MCP tools for memory store/recall/forget/configure — agents can query their own memory history without custom code
- RocksDB + HNSW vector search backend, fully self-hosted on your infra
- 87.8% LoCoMo benchmark score for long-term conversational memory
- Deployed via Docker Compose alongside other DevOps tooling

**DevOps use case:**
AI agents assisting with incident response, deployment decisions, or runbook automation can remember past incidents, solutions, and configuration context across sessions without re-providing context each time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for a new self-hosted agent memory server resource, providing information on its 83 integrated tools, persistent decay-weighted episodic memory capabilities, and recommended deployment architecture with technology stack guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-devops-mcp-servers/pull/206)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->