### PR TITLE
Add Certvo accessibility testing MCP server to Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,3 +387,7 @@ Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+
+## Testing & Chaos Engineering
+- [Certvo](https://certvo.com/docs/mcp) ☁️ 📇 - Accessibility testing MCP server: WCAG 2.1 A/AA/AAA scanning via Playwright + axe-core, AI-generated code fixes, alt text, and VPAT 2.4 reports. Free tier. `claude mcp add --transport http certvo https://certvo.com/api/mcp/`
+


### PR DESCRIPTION
Hi! Submitting Certvo for the Testing & Chaos Engineering section.

Certvo is an MCP server for accessibility testing — WCAG 2.1 A/AA/AAA scanning via Playwright + axe-core, with AI-generated code fixes (not just issue reports). Useful in DevOps pipelines to catch accessibility regressions before they ship.

Tools exposed over MCP:
- Accessibility scan (URL or HTML snippet)
- AI fix generation (returns patched HTML/CSS/JS using Claude AI)
- Alt text generation for images
- VPAT 2.4 report generation

Add to Claude Code or Claude Desktop:
```
claude mcp add --transport http certvo https://certvo.com/api/mcp/
```

- Free tier: anonymous scans + 10 AI fixes/month
- Docs: https://certvo.com/docs/mcp

Happy to revise or move to a different section if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Testing & Chaos Engineering section documenting Certvo, an accessibility testing tool
  * Documentation includes WCAG scanning capabilities, AI-generated code fixes, and VPAT report support
  * Provided setup instructions for the new server

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-devops-mcp-servers/pull/207)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->