### PR TITLE
Add Certvo accessibility testing MCP server to Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Code execution servers. Allow LLMs to execute code in a secure environment.
 ### 🧪 Testing & Chaos Engineering
 Tools for testing, fault injection, and resilience validation.
 
+- [Certvo](https://certvo.com/docs/mcp) ☁️ 📇 - Accessibility testing MCP server: WCAG 2.1 A/AA/AAA scanning via Playwright + axe-core, AI-generated code fixes, alt text, and VPAT 2.4 reports. Free tier. `claude mcp add --transport http certvo https://certvo.com/api/mcp/`
 - [Typewise/mcp-chaos-rig](https://github.com/Typewise/mcp-chaos-rig) 📇 🏠 - A local MCP server that breaks on demand. Test your client against auth failures, disappearing tools, flaky responses, and token expiry, all from a web UI.
 - [ai-dashboad/flutter-skill](https://github.com/ai-dashboad/flutter-skill) - AI-powered E2E testing bridge for any app. Supports Flutter, iOS, Android, Web, Electron, Tauri, KMP, React Native, .NET MAUI.
 - [autonomous-testing/wopee-mcp](https://www.npmjs.com/package/wopee-mcp) 📇 ☁️ - AI testing agents for web apps — dispatch test runs, analysis crawls, and AI agent tests, fetch artifacts and project status.


### PR DESCRIPTION
Hi! Submitting Certvo for the Testing & Chaos Engineering section.

Certvo is an MCP server for accessibility testing — WCAG 2.1 A/AA/AAA scanning via Playwright + axe-core, with AI-generated code fixes (not just issue reports). Useful in DevOps pipelines to catch accessibility regressions before they ship.

Tools exposed over MCP:
- Accessibility scan (URL or HTML snippet)
- AI fix generation (returns patched HTML/CSS/JS using Claude AI)
- Alt text generation for images
- VPAT 2.4 report generation

Add to Claude Code or Claude Desktop:
```
claude mcp add --transport http certvo https://certvo.com/api/mcp/
```

- Free tier: anonymous scans + 10 AI fixes/month
- Docs: https://certvo.com/docs/mcp

Happy to revise or move to a different section if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for accessibility testing capabilities, including WCAG 2.1 compliance scanning, automated code fixes, alt text generation, and VPAT 2.4 reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-devops-mcp-servers/pull/208)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->