### PR TITLE
Add click-to-mcp, deploydiff, and configdrift MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Run commands, capture output and otherwise interact with shells and command line
 - [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 📇 🏠 🍎 🪟 🐧 - A swiss-army-knife that can manage/execute programs and read/write/search/edit code and text files.
 - [YawLabs/tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) 📇 ☁️ — Manage Tailscale tailnets with 52 tools for devices, ACL policies, DNS, auth keys, users, webhooks, and audit logs.
 - [nylas/cli](https://github.com/nylas/cli) 🏎️ ☁️ 🍎 🪟 🐧 - Email, calendar, contacts, webhook, timezone, and OTP command-line tool with built-in MCP server support.
+- [Coding-Dev-Tools/click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) 🐍 🏠 🍎 🪟 🐧 - Auto-wrap any Click/typer CLI as an MCP server. Instantly expose CLI tools to AI assistants without manual integration.
 
 ### 🔄 Version Control
 Interact with Git repositories and version control platforms. Enables repository management, code analysis, pull request handling, issue tracking, and other version control operations through standardized APIs.
@@ -195,6 +196,8 @@ Tools for providing visibility across the entire DevOps lifecycle.
 - [SBDI/mcp-devps-hub](https://github.com/SBDI/mcp-devps-hub) 🐍 🏠 - MCP server for end-to-end development visibility (Jira, GitHub, CI/CD, etc.).
 - [Acid-base/FastMCP-Proper](https://github.com/Acid-base/FastMCP-Proper) 🐍 🏠 - Python MCP server with CI/CD tooling and testability built-in.
 - [gofireflyio/firefly-mcp](https://github.com/gofireflyio/firefly-mcp) 🎖️ 📇 ☁️ - Integrates, discovers, manages, and codifies cloud resources with [Firefly](https://firefly.ai).
+- [Coding-Dev-Tools/deploydiff](https://github.com/Coding-Dev-Tools/deploydiff) 🐍 🏠 🍎 🪟 🐧 - Preview infrastructure changes (Terraform, CloudFormation, Pulumi) with cost impact and rollback commands as an MCP server.
+- [Coding-Dev-Tools/configdrift](https://github.com/Coding-Dev-Tools/configdrift) 🐍 🏠 🍎 🪟 🐧 - Detect and fix configuration file drift across environments (YAML, JSON, TOML, .env) via MCP server.
 
 ### 👨‍💻 Code Execution
 Code execution servers. Allow LLMs to execute code in a secure environment.


### PR DESCRIPTION
## Added 3 DevOps-focused MCP servers

### 🖥️ Command Line
- **[click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp)** 🐍 🏠 🍎 🪟 🐧 - Auto-wrap any Click/typer CLI as an MCP server. Instantly expose existing CLI tools to AI assistants without manual integration. Useful for DevOps teams who want to make their custom CLI tools available to AI coding agents.

### 🔄 DevOps Visibility
- **[deploydiff](https://github.com/Coding-Dev-Tools/deploydiff)** 🐍 🏠 🍎 🪟 🐧 - Preview infrastructure changes (Terraform, CloudFormation, Pulumi) with cost impact analysis and rollback commands. Helps AI assistants understand deployment impact before applying changes.

- **[configdrift](https://github.com/Coding-Dev-Tools/configdrift)** 🐍 🏠 🍎 🪟 🐧 - Detect and fix configuration file drift across environments (YAML, JSON, TOML, .env). Enables AI assistants to identify and remediate configuration inconsistencies.

All three are:
- Python-based (🐍)
- Run locally (🏠)
- Cross-platform (🍎 🪟 🐧)
- Active and maintained
- Follow the existing entry format with proper emoji annotations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the curated MCP server list with new DevOps-related entries.
  * Added a new CLI-wrapping server under Command Line.
  * Added two new MCP servers under CI/CD & DevOps Pipelines for infrastructure preview with cost and rollback impact analysis, and configuration drift detection and correction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-devops-mcp-servers/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->