### PR TITLE
Add click-to-mcp: Convert any CLI tool into an MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Interact with databases, execute queries, inspect schemas, and manage data.
 ### 🖥️ Command Line
 Run commands, capture output and otherwise interact with shells and command line tools.
 
+- [Coding-Dev-Tools/click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) 🐍 🏠 ☁️ 🍎 🪟 🐧 - Converts any Python Click or Typer CLI into an MCP server automatically — zero-code transformation. Supports FastMCP, stdio, and SSE transport with automatic tool discovery.
 - [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) 🖥️ 🛠️ 💬 - A Model Context Protocol server that provides access to iTerm. You can run commands and ask questions about what you see in the iTerm terminal.
 - [g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands) 📇 🏠 - Run any command with `run_command` and `run_script` tools.
 - [maxim-saplin/mcp_safe_local_python_executor](https://github.com/maxim-saplin/mcp_safe_local_python_executor) - Safe Python interpreter based on HF Smolagents `LocalPythonExecutor`

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Run commands, capture output and otherwise interact with shells and command line
 - [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 📇 🏠 🍎 🪟 🐧 - A swiss-army-knife that can manage/execute programs and read/write/search/edit code and text files.
 - [YawLabs/tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) 📇 ☁️ — Manage Tailscale tailnets with 52 tools for devices, ACL policies, DNS, auth keys, users, webhooks, and audit logs.
 - [nylas/cli](https://github.com/nylas/cli) 🏎️ ☁️ 🍎 🪟 🐧 - Email, calendar, contacts, webhook, timezone, and OTP command-line tool with built-in MCP server support.
+ - [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) 🐍 🏠 🐧 🪟 🍎 - Auto-wrap any Click/Typer CLI tool as an MCP server, making existing DevOps tools accessible to AI assistants.
 
 ### 🔄 Version Control
 Interact with Git repositories and version control platforms. Enables repository management, code analysis, pull request handling, issue tracking, and other version control operations through standardized APIs.


### PR DESCRIPTION
Closing duplicate PR. Kept #213 as the single-tool submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Command Line entry for click-to-mcp to the README describing the project and usage notes.
  * A second, shorter entry for the same project was also added later; one entry is more detailed than the other.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-devops-mcp-servers/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->