### PR TITLE
Add click-to-mcp: auto-convert any Click/Typer CLI to MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Interact with databases, execute queries, inspect schemas, and manage data.
 ### 🖥️ Command Line
 Run commands, capture output and otherwise interact with shells and command line tools.
 
+- [Coding-Dev-Tools/click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) 🐍 🏠 ☁️ 🍎 🪟 🐧 - Converts any Python Click or Typer CLI into an MCP server automatically — zero-code transformation. Supports FastMCP, stdio, and SSE transport with automatic tool discovery.
 - [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) 🖥️ 🛠️ 💬 - A Model Context Protocol server that provides access to iTerm. You can run commands and ask questions about what you see in the iTerm terminal.
 - [g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands) 📇 🏠 - Run any command with `run_command` and `run_script` tools.
 - [maxim-saplin/mcp_safe_local_python_executor](https://github.com/maxim-saplin/mcp_safe_local_python_executor) - Safe Python interpreter based on HF Smolagents `LocalPythonExecutor`


### PR DESCRIPTION
## Summary

This PR adds [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) to the ### 🖥️ Command Line section.

## About click-to-mcp

**click-to-mcp** automatically converts any Python Click or Typer CLI into an MCP server with zero code changes. It supports FastMCP, stdio, and SSE transport with automatic tool discovery.

```bash
pip install click-to-mcp
click-to-mcp my_cli.py
```

- **Repository**: https://github.com/Coding-Dev-Tools/click-to-mcp
- **Installation**: `pip install click-to-mcp`
- **Language**: Python (🐍)
- **Scope**: Local (🏠) + Cloud SSE (☁️)
- **Platform**: Cross-platform (🍎 🪟 🐧)

This is a perfect fit for the Command Line section — it bridges the gap between existing CLI tools and MCP, enabling any Click or Typer-based CLI to become an MCP server instantly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to include a new automated MCP server generator tool for Python Click/Typer command-line interfaces with FastMCP integration and transport/tool discovery support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-devops-mcp-servers/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->