### PR TITLE
Add Inference Labs MCP under API Cost Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Tools for persistent memory, context management, and knowledge retention for AI 
 ### 💰 API Cost Management
 Tools for tracking and comparing model/API pricing for AI-agent workloads.
 - [benbencodes/llm-prices](https://github.com/benbencodes/llm-prices) 🐍 🏠 - Zero-dependency Python CLI, library, and MCP server for calculating and comparing LLM API costs across major providers.
-- [bosslesss/inference-labs-mcp](https://github.com/bosslesss/inference-labs-mcp) 🐍 ☁️ 💵 - MCP server for vendor-neutral LLM routing across OpenAI/Azure, Anthropic, Google, and Bedrock, including auth-free pricing lookup and model recommendation tools.
+- [bosslesss/inference-labs-mcp](https://github.com/bosslesss/inference-labs-mcp) ?? ?? - MCP server for vendor-neutral LLM routing across OpenAI/Azure, Anthropic, Google, and Bedrock, including auth-free pricing lookup and model recommendation tools.
 
 ## Frameworks
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Tools for persistent memory, context management, and knowledge retention for AI 
 ### 💰 API Cost Management
 Tools for tracking and comparing model/API pricing for AI-agent workloads.
 - [benbencodes/llm-prices](https://github.com/benbencodes/llm-prices) 🐍 🏠 - Zero-dependency Python CLI, library, and MCP server for calculating and comparing LLM API costs across major providers.
+- [bosslesss/inference-labs-mcp](https://github.com/bosslesss/inference-labs-mcp) 🐍 ☁️ 💵 - MCP server for vendor-neutral LLM routing across OpenAI/Azure, Anthropic, Google, and Bedrock, including auth-free pricing lookup and model recommendation tools.
 
 ## Frameworks
 


### PR DESCRIPTION
Hi! This PR adds [bosslesss/inference-labs-mcp](https://github.com/bosslesss/inference-labs-mcp) to **AI Agent Infrastructure -> API Cost Management**.

Why it fits:

- Includes auth-free pricing and model recommendation MCP tools for cost-aware decisions.
- Adds vendor-neutral routing across major providers (OpenAI/Azure, Anthropic, Google, Bedrock).
- Useful for cost/latency policy-based model selection in agent workloads.

Happy to adjust wording or section placement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a vendor-neutral LLM routing service (bosslesss/inference-labs-mcp) under "💰 API Cost Management."
  * Describes auth-free pricing lookup and model recommendation tools to help compare costs and select models across OpenAI/Azure, Anthropic, Google, and Bedrock.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-devops-mcp-servers/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->