### PR TITLE
Add friendlygeorge/docker-mcp-server to Container Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Tools for managing containers, Kubernetes clusters, and related orchestration pl
 - [kocierik/mcp-nomad](https://github.com/kocierik/mcp-nomad) 🏎️ ☁️/🏠 - MCP Server for nomad management, and analyze your cluster, application health, logs and ACL.
 - [aadarshjain/kubectl-mcp-server](https://github.com/aadarshjain/kubectl-mcp-server) 🐍 🏠 - A STDIO based MCP server for Kubernetes that interacts seamlessly with your local clusters (~/.kube/config) using `kubectl` CLI commands. Uses read-only operations by default to prevent accidental modifications/deletion of K8s resources.
 - [rog0x/mcp-docker-tools](https://github.com/rog0x/mcp-docker-tools) 📇 🏠 - Container management, image analysis, Dockerfile generation, compose validation, and resource monitoring.
+- [friendlygeorge/docker-mcp-server](https://github.com/friendlygeorge/docker-mcp-server) 📇 🏠 - Docker management via MCP: health checks, auto-restart, compose lifecycle, and container operations for AI agents.
 
 ### ☁️ Cloud Providers
 


### PR DESCRIPTION
Adds [friendlygeorge/docker-mcp-server](https://github.com/friendlygeorge/docker-mcp-server) to the Container Orchestration section.

**What it does:** Docker management via MCP with health checks, auto-restart, compose lifecycle, and container operations for AI agents.

**How it differs from existing entries:**
- vs : Focuses on production container lifecycle (health probes, auto-restart, restart policies) rather than Dockerfile generation and analysis
- Compose-as-tools pattern: Each docker-compose service becomes an MCP tool, enabling agents to manage multi-service deployments naturally
- Auto-pull missing images: Containers auto-pull images on start, reducing agent friction

**npm:**  (published, v0.1.6)
**Status:** Active development, 20/20 unit tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added server implementation documentation to README for a Docker management solution featuring health checks, auto-restart capabilities, compose lifecycle management, and container operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->