### PR TITLE
Add cron-scheduler-mcp-server to Command Line section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Run commands, capture output and otherwise interact with shells and command line
 - [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 📇 🏠 🍎 🪟 🐧 - A swiss-army-knife that can manage/execute programs and read/write/search/edit code and text files.
 - [YawLabs/tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) 📇 ☁️ — Manage Tailscale tailnets with 52 tools for devices, ACL policies, DNS, auth keys, users, webhooks, and audit logs.
 - [nylas/cli](https://github.com/nylas/cli) 🏎️ ☁️ 🍎 🪟 🐧 - Email, calendar, contacts, webhook, timezone, and OTP command-line tool with built-in MCP server support.
+- [friendlygeorge/cron-scheduler-mcp-server](https://github.com/friendlygeorge/cron-scheduler-mcp-server) 🏎️ 🏠 🐧 🪟 - Cron job scheduling with SQLite persistence, retry logic, and structured observability. 7 tools: list/create/delete/run/status/logs/pause_resume.
 
 ### 🔄 Version Control
 Interact with Git repositories and version control platforms. Enables repository management, code analysis, pull request handling, issue tracking, and other version control operations through standardized APIs.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Tools for managing containers, Kubernetes clusters, and related orchestration pl
 - [kocierik/mcp-nomad](https://github.com/kocierik/mcp-nomad) 🏎️ ☁️/🏠 - MCP Server for nomad management, and analyze your cluster, application health, logs and ACL.
 - [aadarshjain/kubectl-mcp-server](https://github.com/aadarshjain/kubectl-mcp-server) 🐍 🏠 - A STDIO based MCP server for Kubernetes that interacts seamlessly with your local clusters (~/.kube/config) using `kubectl` CLI commands. Uses read-only operations by default to prevent accidental modifications/deletion of K8s resources.
 - [rog0x/mcp-docker-tools](https://github.com/rog0x/mcp-docker-tools) 📇 🏠 - Container management, image analysis, Dockerfile generation, compose validation, and resource monitoring.
+- [friendlygeorge/docker-mcp-server](https://github.com/friendlygeorge/docker-mcp-server) 📇 🏠 - Docker management via MCP: health checks, auto-restart, compose lifecycle, and container operations for AI agents.
 
 ### ☁️ Cloud Providers
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Run commands, capture output and otherwise interact with shells and command line
 - [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 📇 🏠 🍎 🪟 🐧 - A swiss-army-knife that can manage/execute programs and read/write/search/edit code and text files.
 - [YawLabs/tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) 📇 ☁️ — Manage Tailscale tailnets with 52 tools for devices, ACL policies, DNS, auth keys, users, webhooks, and audit logs.
 - [nylas/cli](https://github.com/nylas/cli) 🏎️ ☁️ 🍎 🪟 🐧 - Email, calendar, contacts, webhook, timezone, and OTP command-line tool with built-in MCP server support.
-- [friendlygeorge/cron-scheduler-mcp-server](https://github.com/friendlygeorge/cron-scheduler-mcp-server) 🏎️ 🏠 🐧 🪟 - Cron job scheduling with SQLite persistence, retry logic, and structured observability. 7 tools: list/create/delete/run/status/logs/pause_resume.
+- [friendlygeorge/cron-scheduler-mcp-server](https://github.com/friendlygeorge/cron-scheduler-mcp-server) 📇 🏠 🐧 🪟 - Cron job scheduling with SQLite persistence, retry logic, and structured observability. 7 tools: list/create/delete/run/status/logs/pause_resume.
 
 ### 🔄 Version Control
 Interact with Git repositories and version control platforms. Enables repository management, code analysis, pull request handling, issue tracking, and other version control operations through standardized APIs.


### PR DESCRIPTION
🤖 **Cron Scheduler MCP Server** — Cron job scheduling with SQLite persistence, retry logic, and structured observability.

**7 tools:** list_jobs, create_job, delete_job, run_now, get_status, get_logs, pause_resume

- **npm:** [@supernova123/cron-scheduler-mcp-server](https://www.npmjs.com/package/@supernova123/cron-scheduler-mcp-server)
- **GitHub:** [friendlygeorge/cron-scheduler-mcp-server](https://github.com/friendlygeorge/cron-scheduler-mcp-server)
- **License:** MIT
- **Features:** SQLite persistence, retry logic with attempt tracking, structured stdout/stderr capture, success rate observability
- **Install:** `npx @supernova123/cron-scheduler-mcp-server`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two new MCP server options to the DevOps servers list: Docker container orchestration and command-line cron scheduling capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->