### PR TITLE
Add ai-economics-mcp to API Cost Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Tools for persistent memory, context management, and knowledge retention for AI 
 ### 💰 API Cost Management
 Tools for tracking and comparing model/API pricing for AI-agent workloads.
 - [benbencodes/llm-prices](https://github.com/benbencodes/llm-prices) 🐍 🏠 - Zero-dependency Python CLI, library, and MCP server for calculating and comparing LLM API costs across major providers.
-- [pich/ai-economics-mcp](https://github.com/pich/ai-economics-mcp) 📇 ☁️ - 12 calculators for AI budget decisions: token cost across vendors, context-window sizing, agent-hour cost (compute + human review), model-routing savings, LLM energy and CO2, joules per verified task, verification bottleneck and proof debt. Keyless free API, stateless. `npx -y @michalpiszczek/ai-economics-mcp`
+- [pich/ai-economics-mcp](https://github.com/pich/ai-economics-mcp) 📇 ☁️ - 12 calculators for AI budget decisions: token cost across vendors, context-window sizing, agent-hour cost (compute + human review), model-routing savings, LLM energy and CO2, joules per verified task, org-wide token burn, humanoid energy budgets, Proof-Adjusted Autonomy, revocation exposure, verification bottleneck and proof debt. Keyless free API, stateless. `npx -y @michalpiszczek/ai-economics-mcp`
 
 ## Frameworks
 

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Tools for persistent memory, context management, and knowledge retention for AI 
 ### 💰 API Cost Management
 Tools for tracking and comparing model/API pricing for AI-agent workloads.
 - [benbencodes/llm-prices](https://github.com/benbencodes/llm-prices) 🐍 🏠 - Zero-dependency Python CLI, library, and MCP server for calculating and comparing LLM API costs across major providers.
-- [pich/ai-economics-mcp](https://github.com/pich/ai-economics-mcp) 📇 ☁️ - 12 calculators for AI budget decisions: token cost across vendors, context-window sizing, agent-hour cost (compute + human review), model-routing savings, LLM energy and CO2, joules per verified task, org-wide token burn, humanoid energy budgets, Proof-Adjusted Autonomy, revocation exposure, verification bottleneck and proof debt. Keyless free API, stateless. `npx -y @michalpiszczek/ai-economics-mcp`
+- [pich/ai-economics-mcp](https://github.com/pich/ai-economics-mcp) 📇 ☁️ - 12 calculators for AI budget decisions: token cost across vendors, context-window sizing, agent-hour cost (compute + human review), model-routing savings, LLM energy and CO2, joules per verified task, org-wide token burn, humanoid energy budgets, Proof-Adjusted Autonomy, revocation exposure, verification bottleneck and proof debt. Keyless free API, stateless. By Michał Piszczek (piszczek.pl). `npx -y @michalpiszczek/ai-economics-mcp`
 
 ## Frameworks
 

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Tools for persistent memory, context management, and knowledge retention for AI 
 ### 💰 API Cost Management
 Tools for tracking and comparing model/API pricing for AI-agent workloads.
 - [benbencodes/llm-prices](https://github.com/benbencodes/llm-prices) 🐍 🏠 - Zero-dependency Python CLI, library, and MCP server for calculating and comparing LLM API costs across major providers.
-- [pich/ai-economics-mcp](https://github.com/pich/ai-economics-mcp) 📇 ☁️ - 12 calculators for AI budget decisions: token cost across vendors, context-window sizing, agent-hour cost (compute + human review), model-routing savings, LLM energy and CO2, joules per verified task, org-wide token burn, humanoid energy budgets, Proof-Adjusted Autonomy, revocation exposure, verification bottleneck and proof debt. Keyless free API, stateless. By Michał Piszczek (piszczek.pl). `npx -y @michalpiszczek/ai-economics-mcp`
+- [pich/ai-economics-mcp](https://github.com/pich/ai-economics-mcp) 📇 ☁️ - 12 calculators for AI budget decisions: token cost across vendors, context-window sizing, agent-hour cost (compute + human review), model-routing savings, LLM energy and CO2, joules per verified task, org-wide token burn, humanoid energy budgets, Proof-Adjusted Autonomy, revocation exposure, verification bottleneck and proof debt. Keyless free API, stateless. By Michał Piszczek — https://piszczek.pl/tools. `npx -y @michalpiszczek/ai-economics-mcp`
 
 ## Frameworks
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Tools for persistent memory, context management, and knowledge retention for AI 
 ### 💰 API Cost Management
 Tools for tracking and comparing model/API pricing for AI-agent workloads.
 - [benbencodes/llm-prices](https://github.com/benbencodes/llm-prices) 🐍 🏠 - Zero-dependency Python CLI, library, and MCP server for calculating and comparing LLM API costs across major providers.
+- [pich/ai-economics-mcp](https://github.com/pich/ai-economics-mcp) 📇 ☁️ - 12 calculators for AI budget decisions: token cost across vendors, context-window sizing, agent-hour cost (compute + human review), model-routing savings, LLM energy and CO2, joules per verified task, verification bottleneck and proof debt. Keyless free API, stateless. `npx -y @michalpiszczek/ai-economics-mcp`
 
 ## Frameworks
 


### PR DESCRIPTION
Adds **[pich/ai-economics-mcp](https://github.com/pich/ai-economics-mcp)** next to `llm-prices` in **💰 API Cost Management** — same problem space, wider scope.

12 tools: token cost across vendors, context-window sizing, agent-hour cost (compute + human verification), model-routing savings, LLM energy & CO₂, joules per verified task, org-wide token burn, humanoid energy budgets, Proof-Adjusted Autonomy, revocation exposure, verification bottleneck, proof debt.

- 📇 TypeScript (Node ≥18, stdio) · ☁️ thin client over a keyless, CORS-open API
- Install: `npx -y @michalpiszczek/ai-economics-mcp`
- Official MCP Registry: `pl.piszczek/ai-economics` (domain-verified)
- Stateless — inputs are never stored; every response carries the formula, an interpretation and a citable source
- OpenAPI 3.1: https://piszczek.pl/openapi.json

Disclosure: PR prepared by an AI agent on behalf of the author (Michał Piszczek).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new API Cost Management resource featuring AI budget calculators.
  * Documented the available command for checking and managing usage.
  * Improved visibility into tools that help estimate and monitor AI-related API costs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->