### PR TITLE
Add SMTPfast MCP server to Alerting & Notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Tools for monitoring social media platforms and extracting data.
 Tools for managing alerts and notifications in monitoring systems.
 
 - [kaznak/alertmanager-mcp](https://github.com/kaznak/alertmanager-mcp) 📇 ☁️ - A Model Context Protocol server that integrates with Prometheus Alertmanager for alert management and notification.
-- [smtpfast/smtpfast](https://github.com/smtpfast/smtpfast) 📇 ☁️ - Transactional email from agents: send, check domain DNS and deliverability, read bounces, complaints and received mail.
+- [SMTPfast MCP Server](https://smtpfa.st/docs/mcp) 📇 ☁️ - Transactional email from agents: send, check domain DNS and deliverability, read bounces, complaints and received mail.
 
 ### 🔍 Application Performance Monitoring
 Tools for monitoring application performance and infrastructure health.

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Tools for monitoring social media platforms and extracting data.
 Tools for managing alerts and notifications in monitoring systems.
 
 - [kaznak/alertmanager-mcp](https://github.com/kaznak/alertmanager-mcp) 📇 ☁️ - A Model Context Protocol server that integrates with Prometheus Alertmanager for alert management and notification.
+- [smtpfast/smtpfast](https://github.com/smtpfast/smtpfast) 📇 ☁️ - Transactional email from agents: send, check domain DNS and deliverability, read bounces, complaints and received mail.
 
 ### 🔍 Application Performance Monitoring
 Tools for monitoring application performance and infrastructure health.


### PR DESCRIPTION
Adds the SMTPfast hosted MCP server (email sending, deliverability checks, bounce and complaint lookups, inbound mail) under Alerting & Notification. Docs: https://smtpfa.st/docs/mcp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the SMTPfast MCP server entry with its correct display name.
  - Added a working documentation URL while preserving the existing description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->